### PR TITLE
Add runtime, docs, and examples

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Q++ Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,25 @@ The demo is purely experimental but serves as a playground for ideas inspired by
 quantum Fourier transforms.
 
 
+
+## Building and Testing
+
+The project uses CMake. A typical build workflow is:
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+ctest
+```
+
+`ctest` executes the small wavefunction simulator tests.
+
+### Python Requirements
+
+To run the demo in `tools/wave_primes.py` install dependencies via:
+
+```bash
+pip install -r requirements.txt
+```
+

--- a/docs/examples/teleport.qpp
+++ b/docs/examples/teleport.qpp
@@ -1,0 +1,20 @@
+// Simple quantum teleportation example
+
+task<QPU> teleport() {
+    qalloc qbit q[3];
+    cregister int c[2];
+
+    // Create Bell pair between qubit1 and qubit2
+    H(q[1]);
+    CX(q[1], q[2]);
+
+    // Entangle message qubit0 with qubit1
+    CX(q[0], q[1]);
+    H(q[0]);
+
+    c[0] = measure(q[0]);
+    c[1] = measure(q[1]);
+
+    if (c[1]) { X(q[2]); }
+    if (c[0]) { Z(q[2]); }
+}

--- a/docs/migration/bitwise_to_gate.md
+++ b/docs/migration/bitwise_to_gate.md
@@ -1,0 +1,19 @@
+# Bitwise Operators and Quantum Gates
+
+Classical bitwise operators translate to specific quantum gate sequences when the operands are backed by `qregister` memory. This table summarises the defaults used by the Q++ compiler:
+
+| Operator | Quantum Equivalent |
+|----------|-------------------|
+| `^`      | Controlled-NOT (CX) |
+| `&`      | Toffoli (CCX) |
+| `|`      | Multi-controlled X |
+| `~`      | X gate (bit flip) |
+
+For example:
+
+```cpp
+qregister bool a, b;
+bool c = a ^ b; // expands to CX with `a` as control and `b` as target
+```
+
+When operands are classical (`cregister` or regular `bool`) the compiler emits normal bitwise instructions.

--- a/docs/migration/bool_logic.md
+++ b/docs/migration/bool_logic.md
@@ -1,0 +1,12 @@
+# Probabilistic Boolean Semantics
+
+Booleans derived from quantum memory behave probabilistically. Reading a `qbit` into a `bool` triggers a measurement, collapsing the qubit state. Until that point the value is undefined and must be treated as a superposition of `true` and `false`.
+
+Conditional statements using such values are deferred to runtime:
+
+```cpp
+qregister bool qflag;
+if (qflag) { /* executed only after measurement */ }
+```
+
+The runtime tracks these deferred branches and resolves them when a measurement occurs. Classical booleans (`cregister` or default `bool`) are evaluated normally.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+scipy
+matplotlib

--- a/runtime/memory.cpp
+++ b/runtime/memory.cpp
@@ -1,0 +1,24 @@
+#include "memory.h"
+
+namespace qpp {
+int MemoryManager::create_qregister(size_t n) {
+    qregs.emplace_back(n);
+    return static_cast<int>(qregs.size() - 1);
+}
+
+int MemoryManager::create_cregister(size_t n) {
+    cregs.emplace_back(n);
+    return static_cast<int>(cregs.size() - 1);
+}
+
+QRegister& MemoryManager::qreg(int id) {
+    return qregs.at(id);
+}
+
+CRegister& MemoryManager::creg(int id) {
+    return cregs.at(id);
+}
+
+MemoryManager memory;
+} // namespace qpp
+

--- a/runtime/memory.h
+++ b/runtime/memory.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <vector>
+#include "wavefunction.h"
+
+namespace qpp {
+struct QRegister {
+    Wavefunction wf;
+    explicit QRegister(size_t n) : wf(n) {}
+};
+
+struct CRegister {
+    std::vector<int> bits;
+    explicit CRegister(size_t n) : bits(n, 0) {}
+};
+
+class MemoryManager {
+public:
+    int create_qregister(size_t n);
+    int create_cregister(size_t n);
+    QRegister& qreg(int id);
+    CRegister& creg(int id);
+private:
+    std::vector<QRegister> qregs;
+    std::vector<CRegister> cregs;
+};
+
+extern MemoryManager memory;
+}
+

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -1,0 +1,33 @@
+#include "scheduler.h"
+#include <iostream>
+
+namespace qpp {
+void Scheduler::add_task(const Task& t) {
+    tasks.push(t);
+}
+
+void Scheduler::run() {
+    while (!tasks.empty()) {
+        Task t = tasks.front();
+        tasks.pop();
+        std::cout << "Running task '" << t.name << "' on ";
+        switch (t.target) {
+        case Target::CPU:
+            std::cout << "CPU";
+            break;
+        case Target::QPU:
+            std::cout << "QPU";
+            break;
+        case Target::AUTO:
+            std::cout << "AUTO";
+            break;
+        }
+        std::cout << std::endl;
+        if (t.handler)
+            t.handler();
+    }
+}
+
+Scheduler scheduler;
+} // namespace qpp
+

--- a/runtime/scheduler.h
+++ b/runtime/scheduler.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <functional>
+#include <queue>
+#include <string>
+
+namespace qpp {
+enum class Target { CPU, QPU, AUTO };
+
+struct Task {
+    std::string name;
+    Target target;
+    std::function<void()> handler;
+};
+
+class Scheduler {
+public:
+    void add_task(const Task& t);
+    void run();
+private:
+    std::queue<Task> tasks;
+};
+
+extern Scheduler scheduler;
+} // namespace qpp
+

--- a/runtime/wavefunction.cpp
+++ b/runtime/wavefunction.cpp
@@ -3,30 +3,81 @@
 #include <random>
 
 namespace qpp {
-Wavefunction::Wavefunction() {
+
+Wavefunction::Wavefunction(std::size_t qubits)
+    : state(1ULL << qubits, {0.0, 0.0}), num_qubits(qubits) {
     state[0] = 1.0;
-    state[1] = 0.0;
 }
 
-void Wavefunction::apply_h() {
-    auto s0 = state[0];
-    auto s1 = state[1];
-    constexpr double factor = 1.0 / std::sqrt(2.0);
-    state[0] = (s0 + s1) * factor;
-    state[1] = (s0 - s1) * factor;
+static void apply_single_qubit_gate(std::vector<std::complex<double>>& st,
+                                    std::size_t target,
+                                    const std::complex<double> mat[2][2]) {
+    std::size_t step = 1ULL << target;
+    for (std::size_t i = 0; i < st.size(); i += 2 * step) {
+        for (std::size_t j = 0; j < step; ++j) {
+            auto a = st[i + j];
+            auto b = st[i + j + step];
+            st[i + j] = mat[0][0] * a + mat[0][1] * b;
+            st[i + j + step] = mat[1][0] * a + mat[1][1] * b;
+        }
+    }
 }
 
-void Wavefunction::apply_x() {
-    auto tmp = state[0];
-    state[0] = state[1];
-    state[1] = tmp;
+void Wavefunction::apply_h(std::size_t qubit) {
+    const double f = 1.0 / std::sqrt(2.0);
+    const std::complex<double> mat[2][2] = {{f, f}, {f, -f}};
+    apply_single_qubit_gate(state, qubit, mat);
 }
 
-int Wavefunction::measure() const {
-    double p0 = std::norm(state[0]);
+void Wavefunction::apply_x(std::size_t qubit) {
+    const std::complex<double> mat[2][2] = {{0, 1}, {1, 0}};
+    apply_single_qubit_gate(state, qubit, mat);
+}
+
+void Wavefunction::apply_y(std::size_t qubit) {
+    const std::complex<double> mat[2][2] = {
+        {0.0, std::complex<double>(0, -1)},
+        {std::complex<double>(0, 1), 0.0}
+    };
+    apply_single_qubit_gate(state, qubit, mat);
+}
+
+void Wavefunction::apply_z(std::size_t qubit) {
+    const std::complex<double> mat[2][2] = {{1, 0}, {0, -1}};
+    apply_single_qubit_gate(state, qubit, mat);
+}
+
+void Wavefunction::apply_cnot(std::size_t control, std::size_t target) {
+    std::size_t cbit = 1ULL << control;
+    std::size_t tbit = 1ULL << target;
+    for (std::size_t i = 0; i < state.size(); ++i) {
+        if ((i & cbit) && !(i & tbit)) {
+            std::size_t j = i | tbit;
+            std::swap(state[i], state[j]);
+        }
+    }
+}
+
+int Wavefunction::measure(std::size_t qubit) {
+    std::size_t bit = 1ULL << qubit;
+    double p1 = 0.0;
+    for (std::size_t i = 0; i < state.size(); ++i) {
+        if (i & bit)
+            p1 += std::norm(state[i]);
+    }
     std::random_device rd;
     std::mt19937 gen(rd());
-    std::bernoulli_distribution d(1.0 - p0);
-    return d(gen); // returns 0 or 1
+    std::bernoulli_distribution dist(p1);
+    int result = dist(gen);
+    double norm_factor = std::sqrt(result ? p1 : 1.0 - p1);
+    for (std::size_t i = 0; i < state.size(); ++i) {
+        if (((i & bit) != 0) != static_cast<bool>(result))
+            state[i] = 0;
+        else
+            state[i] /= norm_factor;
+    }
+    return result;
 }
+
 } // namespace qpp
+

--- a/runtime/wavefunction.h
+++ b/runtime/wavefunction.h
@@ -2,17 +2,25 @@
 #define QPP_WAVEFUNCTION_H
 
 #include <complex>
-#include <array>
+#include <vector>
+#include <cstddef>
 
 namespace qpp {
 class Wavefunction {
 public:
-    Wavefunction();
-    void apply_h();
-    void apply_x();
-    int measure() const;
-    std::array<std::complex<double>, 2> state;
+    explicit Wavefunction(std::size_t qubits = 1);
+
+    void apply_h(std::size_t qubit);
+    void apply_x(std::size_t qubit);
+    void apply_y(std::size_t qubit);
+    void apply_z(std::size_t qubit);
+    void apply_cnot(std::size_t control, std::size_t target);
+
+    int measure(std::size_t qubit);
+
+    std::vector<std::complex<double>> state;
+    std::size_t num_qubits;
 };
-}
+} // namespace qpp
 
 #endif // QPP_WAVEFUNCTION_H

--- a/tests/wavefunction_test.cpp
+++ b/tests/wavefunction_test.cpp
@@ -4,18 +4,25 @@
 #include <iostream>
 
 int main() {
-    qpp::Wavefunction wf;
-    // apply Hadamard gate to |0>
-    wf.apply_h();
-    double p0 = std::norm(wf.state[0]);
-    double p1 = std::norm(wf.state[1]);
-    assert(std::abs(p0 - 0.5) < 1e-6);
-    assert(std::abs(p1 - 0.5) < 1e-6);
-
-    // apply X gate; should swap amplitudes
-    wf.apply_x();
+    using namespace qpp;
+    // single qubit tests
+    Wavefunction wf(1);
+    wf.apply_h(0);
     assert(std::abs(std::norm(wf.state[0]) - 0.5) < 1e-6);
     assert(std::abs(std::norm(wf.state[1]) - 0.5) < 1e-6);
+
+    wf.apply_x(0);
+    wf.apply_y(0);
+    wf.apply_z(0);
+
+    // two qubit entanglement
+    Wavefunction ent(2);
+    ent.apply_h(0);
+    ent.apply_cnot(0,1);
+    double p00 = std::norm(ent.state[0]);
+    double p11 = std::norm(ent.state[3]);
+    assert(std::abs(p00 - 0.5) < 1e-6);
+    assert(std::abs(p11 - 0.5) < 1e-6);
 
     std::cout << "Wavefunction simulator tests passed." << std::endl;
     return 0;

--- a/tools/qpp-run.cpp
+++ b/tools/qpp-run.cpp
@@ -1,10 +1,31 @@
+#include "../runtime/scheduler.h"
+#include <fstream>
 #include <iostream>
+#include <sstream>
+
+using namespace qpp;
 
 int main(int argc, char** argv) {
     if (argc < 2) {
         std::cerr << "Usage: qpp-run <compiled.ir>\n";
         return 1;
     }
-    std::cout << "Executing " << argv[1] << " (runtime stub)" << std::endl;
+    std::ifstream input(argv[1]);
+    if (!input.is_open()) {
+        std::cerr << "Failed to open " << argv[1] << "\n";
+        return 1;
+    }
+    std::string line;
+    while (std::getline(input, line)) {
+        std::istringstream iss(line);
+        std::string tag, target_str, name;
+        iss >> tag >> target_str >> name;
+        if (tag != "TASK") continue;
+        Target t = Target::AUTO;
+        if (target_str == "CPU") t = Target::CPU;
+        else if (target_str == "QPU") t = Target::QPU;
+        scheduler.add_task({name, t, []{}});
+    }
+    scheduler.run();
     return 0;
 }

--- a/tools/qppc.cpp
+++ b/tools/qppc.cpp
@@ -1,11 +1,11 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <regex>
 #include <string>
 
 int main(int argc, char** argv) {
-    if (argc < 2) {
-        std::cerr << "Usage: qppc <source.qpp>\n";
+    if (argc < 3) {
+        std::cerr << "Usage: qppc <source.qpp> <output.ir>\n";
         return 1;
     }
     std::ifstream input(argv[1]);
@@ -13,14 +13,19 @@ int main(int argc, char** argv) {
         std::cerr << "Failed to open " << argv[1] << "\n";
         return 1;
     }
-    std::string line;
+    std::ofstream out(argv[2]);
+    if (!out.is_open()) {
+        std::cerr << "Failed to create " << argv[2] << "\n";
+        return 1;
+    }
     std::regex task_regex(R"(task<\s*(CPU|QPU|AUTO)\s*>\s*(\w+)\s*\()");
+    std::string line;
     while (std::getline(input, line)) {
         std::smatch match;
         if (std::regex_search(line, match, task_regex)) {
-            std::cout << "Found task '" << match[2] << "' targeting " << match[1] << "\n";
+            out << "TASK " << match[1] << " " << match[2] << "\n";
         }
     }
-    std::cout << "Parsing complete." << std::endl;
+    std::cout << "Compilation complete." << std::endl;
     return 0;
 }


### PR DESCRIPTION
## Summary
- implement basic memory manager and scheduler in runtime
- extend wavefunction library with more gates and qubit support
- update tooling to produce simple IR and run through scheduler
- document bitwise and boolean semantics
- add teleportation example and build instructions
- include Python requirements and MIT license

## Testing
- `cmake ..`
- `make -j2`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6844204c92d8832f8091437cd9be0ece