### PR TITLE
Improve repo TODO visibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug Report
+about: Create a report to help us improve Q++
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+---
+name: Feature Request
+about: Suggest an idea for Q++
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,15 @@
+name: CMake
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build -j 2
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,4 +25,16 @@ if(BUILD_TESTING)
     add_executable(wavefunction_test tests/wavefunction_test.cpp)
     target_link_libraries(wavefunction_test PRIVATE qpp_runtime)
     add_test(NAME wavefunction_test COMMAND wavefunction_test)
+
+    add_executable(wavefunction_extra_test tests/wavefunction_extra_test.cpp)
+    target_link_libraries(wavefunction_extra_test PRIVATE qpp_runtime)
+    add_test(NAME wavefunction_extra_test COMMAND wavefunction_extra_test)
+
+    add_executable(scheduler_test tests/scheduler_test.cpp)
+    target_link_libraries(scheduler_test PRIVATE qpp_runtime)
+    add_test(NAME scheduler_test COMMAND scheduler_test)
+
+    add_executable(memory_test tests/memory_test.cpp)
+    target_link_libraries(memory_test PRIVATE qpp_runtime)
+    add_test(NAME memory_test COMMAND memory_test)
 endif()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to Q++
+
+Thank you for considering contributing to Q++! This project experiments with blending classical C++ and quantum concepts. To keep the code base consistent, please follow these guidelines.
+
+## Development workflow
+
+1. Fork the repository and create feature branches from `main`.
+2. Build using CMake:
+   ```bash
+   mkdir build && cd build
+   cmake ..
+   make -j
+   ctest --output-on-failure
+   ```
+3. Submit pull requests with clear descriptions of what was added or changed.
+
+## Code style
+
+- Use modern C++17 features but avoid heavy template metaprogramming.
+- Keep headers lightweight and minimize global state.
+- Document TODOs where architectural decisions are still open.
+
+## Issues and discussions
+
+Bug reports and feature requests are welcome in GitHub issues. Please provide steps to reproduce when filing bugs.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Q++ Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,27 @@ The demo is purely experimental but serves as a playground for ideas inspired by
 quantum Fourier transforms.
 
 
+
+## Building and Testing
+
+The project uses CMake. A typical build workflow is:
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+ctest
+```
+
+`ctest` executes the small wavefunction simulator tests.
+
+### Python Requirements
+
+To run the demo in `tools/wave_primes.py` install dependencies via:
+
+```bash
+pip install -r requirements.txt
+```
+
+For contribution guidelines see [CONTRIBUTING.md](CONTRIBUTING.md).
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,13 @@
+# Project TODOs
+
+The following tasks were outlined before open-sourcing and are now mostly addressed:
+
+- Basic parser and IR generation in `qppc`.
+- IR execution via `qpp-run` using the runtime scheduler and memory manager.
+- Thread-safe `MemoryManager` and `Scheduler` with simple error handling.
+- Extra quantum gates (S, T, SWAP) added to the `Wavefunction` class.
+- Expanded test suite covering additional gates and multi-threaded memory use.
+- Initial contribution guidelines and issue templates.
+
+Further work is needed to refine the IR format, improve error diagnostics, and flesh out compiler backends.
+

--- a/docs/architecture/02-runtime.md
+++ b/docs/architecture/02-runtime.md
@@ -100,5 +100,12 @@ Defines available QPUs, simulators, and constraints like:
 
 ---
 
+### Scheduler Overview
+The reference runtime ships with a simple FIFO scheduler. Tasks added via
+`scheduler.add_task` are executed sequentially. When a `task<QPU>` handler is
+invoked, it operates on registers managed by `MemoryManager` and can apply gates
+through the `QRegister` interface. CPU tasks run regular C++ functions and may
+interact with classical registers.
+
 *End of Runtime Spec v0.1*
 

--- a/docs/examples/adaptive_task.qpp
+++ b/docs/examples/adaptive_task.qpp
@@ -1,0 +1,11 @@
+// Adaptive task that branches based on measurement
+
+task<QPU> adaptive(qregister q[2]) {
+    H(q[0]);
+    int m = measure(q[0]);
+    if (m) {
+        X(q[1]);
+    } else {
+        Z(q[1]);
+    }
+}

--- a/docs/examples/teleport.qpp
+++ b/docs/examples/teleport.qpp
@@ -1,0 +1,20 @@
+// Simple quantum teleportation example
+
+task<QPU> teleport() {
+    qalloc qbit q[3];
+    cregister int c[2];
+
+    // Create Bell pair between qubit1 and qubit2
+    H(q[1]);
+    CX(q[1], q[2]);
+
+    // Entangle message qubit0 with qubit1
+    CX(q[0], q[1]);
+    H(q[0]);
+
+    c[0] = measure(q[0]);
+    c[1] = measure(q[1]);
+
+    if (c[1]) { X(q[2]); }
+    if (c[0]) { Z(q[2]); }
+}

--- a/docs/migration/asm_vs_qasm.md
+++ b/docs/migration/asm_vs_qasm.md
@@ -1,0 +1,17 @@
+# Inline Assembly vs Inline QASM
+
+Q++ allows embedding low level code for both the CPU and the QPU.
+Classical `asm` blocks behave exactly like they do in C++ and are executed on the CPU.
+The `__qasm` keyword introduces a block of quantum assembly instructions that
+operate on `qregister` state.
+
+```cpp
+asm volatile("movl $1, %eax");       // CPU assembly
+__qasm {
+  H 0;
+  CX 0,1;
+}
+```
+
+The compiler keeps these sections separate so that quantum instructions can be
+sent to a simulator or real device while classical assembly executes normally.

--- a/docs/migration/bitwise_to_gate.md
+++ b/docs/migration/bitwise_to_gate.md
@@ -1,0 +1,19 @@
+# Bitwise Operators and Quantum Gates
+
+Classical bitwise operators translate to specific quantum gate sequences when the operands are backed by `qregister` memory. This table summarises the defaults used by the Q++ compiler:
+
+| Operator | Quantum Equivalent |
+|----------|-------------------|
+| `^`      | Controlled-NOT (CX) |
+| `&`      | Toffoli (CCX) |
+| `|`      | Multi-controlled X |
+| `~`      | X gate (bit flip) |
+
+For example:
+
+```cpp
+qregister bool a, b;
+bool c = a ^ b; // expands to CX with `a` as control and `b` as target
+```
+
+When operands are classical (`cregister` or regular `bool`) the compiler emits normal bitwise instructions.

--- a/docs/migration/bool_logic.md
+++ b/docs/migration/bool_logic.md
@@ -1,0 +1,12 @@
+# Probabilistic Boolean Semantics
+
+Booleans derived from quantum memory behave probabilistically. Reading a `qbit` into a `bool` triggers a measurement, collapsing the qubit state. Until that point the value is undefined and must be treated as a superposition of `true` and `false`.
+
+Conditional statements using such values are deferred to runtime:
+
+```cpp
+qregister bool qflag;
+if (qflag) { /* executed only after measurement */ }
+```
+
+The runtime tracks these deferred branches and resolves them when a measurement occurs. Classical booleans (`cregister` or default `bool`) are evaluated normally.

--- a/docs/migration/ir_and_probabilities.md
+++ b/docs/migration/ir_and_probabilities.md
@@ -1,0 +1,6 @@
+# IR and Probabilities
+
+Q++ extends LLVM IR with metadata describing probabilistic branches. Each
+measurement inserts a `@collapse` marker so that the runtime knows when to
+resolve deferred scopes. This metadata also allows external simulators to
+reconstruct the full quantum state when running offline analyses.

--- a/docs/migration/register_mapping.md
+++ b/docs/migration/register_mapping.md
@@ -1,0 +1,12 @@
+# Register Mapping
+
+When migrating C++ code to Q++, register declarations map to specific memory
+banks depending on context.
+
+- `register` – inferred by the compiler; may become a classical or quantum
+  register based on usage.
+- `cregister` – forces classical storage; lives purely in CPU memory.
+- `qregister` – allocates qubits in the simulator or on a QPU.
+
+MemoryManager keeps separate pools for classical and quantum registers and errors
+if an invalid ID is used or a register is freed twice.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+scipy
+matplotlib

--- a/runtime/memory.cpp
+++ b/runtime/memory.cpp
@@ -1,0 +1,52 @@
+#include "memory.h"
+#include <stdexcept>
+#include <mutex>
+
+namespace qpp {
+// TODO: track register usage statistics for debugging
+int MemoryManager::create_qregister(size_t n) {
+    std::lock_guard<std::mutex> lock(mtx);
+    qregs.push_back(std::make_unique<QRegister>(n));
+    return static_cast<int>(qregs.size() - 1);
+}
+
+bool MemoryManager::release_qregister(int id) {
+    std::lock_guard<std::mutex> lock(mtx);
+    if (id < 0 || id >= static_cast<int>(qregs.size()) || !qregs[id])
+        return false;
+    qregs[id].reset();
+    return true;
+}
+
+int MemoryManager::create_cregister(size_t n) {
+    std::lock_guard<std::mutex> lock(mtx);
+    cregs.push_back(std::make_unique<CRegister>(n));
+    return static_cast<int>(cregs.size() - 1);
+}
+
+bool MemoryManager::release_cregister(int id) {
+    std::lock_guard<std::mutex> lock(mtx);
+    if (id < 0 || id >= static_cast<int>(cregs.size()) || !cregs[id])
+        return false;
+    cregs[id].reset();
+    return true;
+}
+
+QRegister& MemoryManager::qreg(int id) {
+    std::lock_guard<std::mutex> lock(mtx);
+    if (id < 0 || id >= static_cast<int>(qregs.size()) || !qregs[id])
+        throw std::out_of_range("invalid qregister id");
+    return *qregs[id];
+}
+
+CRegister& MemoryManager::creg(int id) {
+    std::lock_guard<std::mutex> lock(mtx);
+    if (id < 0 || id >= static_cast<int>(cregs.size()) || !cregs[id])
+        throw std::out_of_range("invalid cregister id");
+    return *cregs[id];
+}
+
+MemoryManager memory;
+// TODO: expose import/export of register states for persistence
+} // namespace qpp
+

--- a/runtime/memory.h
+++ b/runtime/memory.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <memory>
+#include <mutex>
+#include <vector>
+#include "wavefunction.h"
+
+namespace qpp {
+struct QRegister {
+    Wavefunction wf;
+    explicit QRegister(size_t n) : wf(n) {}
+
+    void h(std::size_t q) { wf.apply_h(q); }
+    void x(std::size_t q) { wf.apply_x(q); }
+    void y(std::size_t q) { wf.apply_y(q); }
+    void z(std::size_t q) { wf.apply_z(q); }
+    void cnot(std::size_t c, std::size_t t) { wf.apply_cnot(c, t); }
+    void s(std::size_t q) { wf.apply_s(q); }
+    void t(std::size_t q) { wf.apply_t(q); }
+    void swap(std::size_t a, std::size_t b) { wf.apply_swap(a, b); }
+    int measure(std::size_t q) { return wf.measure(q); }
+    void resize(std::size_t n) { wf = Wavefunction(n); }
+};
+
+// TODO: enhance QRegister to support saving/loading state and lazy allocation
+
+struct CRegister {
+    std::vector<int> bits;
+    explicit CRegister(size_t n) : bits(n, 0) {}
+};
+
+class MemoryManager {
+public:
+    int create_qregister(size_t n);
+    bool release_qregister(int id);
+    int create_cregister(size_t n);
+    bool release_cregister(int id);
+    QRegister& qreg(int id);
+    CRegister& creg(int id);
+private:
+    std::vector<std::unique_ptr<QRegister>> qregs;
+    std::vector<std::unique_ptr<CRegister>> cregs;
+    std::mutex mtx;
+};
+
+// TODO: support register reuse and bulk operations
+
+extern MemoryManager memory;
+}
+

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -1,0 +1,42 @@
+#include "scheduler.h"
+#include <iostream>
+#include <mutex>
+
+namespace qpp {
+// TODO: hook into real QPU execution engines
+void Scheduler::add_task(const Task& t) {
+    std::lock_guard<std::mutex> lock(mtx);
+    tasks.push(t);
+}
+
+void Scheduler::run() {
+    for (;;) {
+        Task t;
+        {
+            std::lock_guard<std::mutex> lock(mtx);
+            if (tasks.empty()) break;
+            t = tasks.front();
+            tasks.pop();
+        }
+        std::cout << "Running task '" << t.name << "' on ";
+        switch (t.target) {
+        case Target::CPU:
+            std::cout << "CPU";
+            break;
+        case Target::QPU:
+            std::cout << "QPU";
+            break;
+        case Target::AUTO:
+            std::cout << "AUTO";
+            break;
+        }
+        std::cout << std::endl;
+        if (t.handler)
+            t.handler();
+    }
+}
+
+Scheduler scheduler;
+// TODO: provide scheduler stop/pause controls
+} // namespace qpp
+

--- a/runtime/scheduler.h
+++ b/runtime/scheduler.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <string>
+
+namespace qpp {
+enum class Target { CPU, QPU, AUTO };
+
+struct Task {
+    std::string name;
+    Target target;
+    std::function<void()> handler;
+};
+
+class Scheduler {
+public:
+    void add_task(const Task& t);
+    void run();
+private:
+    std::queue<Task> tasks;
+    std::mutex mtx;
+};
+
+// TODO: extend Scheduler with priorities and asynchronous execution
+
+extern Scheduler scheduler;
+} // namespace qpp
+

--- a/runtime/wavefunction.cpp
+++ b/runtime/wavefunction.cpp
@@ -3,30 +3,114 @@
 #include <random>
 
 namespace qpp {
-Wavefunction::Wavefunction() {
+// TODO: consolidate random engine usage across the runtime
+
+Wavefunction::Wavefunction(std::size_t qubits)
+    : state(1ULL << qubits, {0.0, 0.0}), num_qubits(qubits) {
     state[0] = 1.0;
-    state[1] = 0.0;
 }
 
-void Wavefunction::apply_h() {
-    auto s0 = state[0];
-    auto s1 = state[1];
-    constexpr double factor = 1.0 / std::sqrt(2.0);
-    state[0] = (s0 + s1) * factor;
-    state[1] = (s0 - s1) * factor;
+static void apply_single_qubit_gate(std::vector<std::complex<double>>& st,
+                                    std::size_t target,
+                                    const std::complex<double> mat[2][2]) {
+    std::size_t step = 1ULL << target;
+    for (std::size_t i = 0; i < st.size(); i += 2 * step) {
+        for (std::size_t j = 0; j < step; ++j) {
+            auto a = st[i + j];
+            auto b = st[i + j + step];
+            st[i + j] = mat[0][0] * a + mat[0][1] * b;
+            st[i + j + step] = mat[1][0] * a + mat[1][1] * b;
+        }
+    }
 }
 
-void Wavefunction::apply_x() {
-    auto tmp = state[0];
-    state[0] = state[1];
-    state[1] = tmp;
+void Wavefunction::apply_h(std::size_t qubit) {
+    const double f = 1.0 / std::sqrt(2.0);
+    const std::complex<double> mat[2][2] = {{f, f}, {f, -f}};
+    apply_single_qubit_gate(state, qubit, mat);
 }
 
-int Wavefunction::measure() const {
-    double p0 = std::norm(state[0]);
+void Wavefunction::apply_x(std::size_t qubit) {
+    const std::complex<double> mat[2][2] = {{0, 1}, {1, 0}};
+    apply_single_qubit_gate(state, qubit, mat);
+}
+
+void Wavefunction::apply_y(std::size_t qubit) {
+    const std::complex<double> mat[2][2] = {
+        {0.0, std::complex<double>(0, -1)},
+        {std::complex<double>(0, 1), 0.0}
+    };
+    apply_single_qubit_gate(state, qubit, mat);
+}
+
+void Wavefunction::apply_z(std::size_t qubit) {
+    const std::complex<double> mat[2][2] = {{1, 0}, {0, -1}};
+    apply_single_qubit_gate(state, qubit, mat);
+}
+
+void Wavefunction::apply_s(std::size_t qubit) {
+    const std::complex<double> mat[2][2] = {
+        {1, 0},
+        {0, std::complex<double>(0, 1)}
+    };
+    apply_single_qubit_gate(state, qubit, mat);
+}
+
+void Wavefunction::apply_t(std::size_t qubit) {
+    const std::complex<double> mat[2][2] = {
+        {1, 0},
+        {0, std::exp(std::complex<double>(0, M_PI / 4))}
+    };
+    apply_single_qubit_gate(state, qubit, mat);
+}
+
+void Wavefunction::apply_swap(std::size_t q1, std::size_t q2) {
+    if (q1 == q2) return;
+    std::size_t bit1 = 1ULL << q1;
+    std::size_t bit2 = 1ULL << q2;
+    for (std::size_t i = 0; i < state.size(); ++i) {
+        bool b1 = i & bit1;
+        bool b2 = i & bit2;
+        if (b1 != b2) {
+            std::size_t j = (i ^ bit1 ^ bit2);
+            if (i < j) std::swap(state[i], state[j]);
+        }
+    }
+}
+
+void Wavefunction::apply_cnot(std::size_t control, std::size_t target) {
+    std::size_t cbit = 1ULL << control;
+    std::size_t tbit = 1ULL << target;
+    for (std::size_t i = 0; i < state.size(); ++i) {
+        if ((i & cbit) && !(i & tbit)) {
+            std::size_t j = i | tbit;
+            std::swap(state[i], state[j]);
+        }
+    }
+}
+
+int Wavefunction::measure(std::size_t qubit) {
+    std::size_t bit = 1ULL << qubit;
+    double p1 = 0.0;
+    for (std::size_t i = 0; i < state.size(); ++i) {
+        if (i & bit)
+            p1 += std::norm(state[i]);
+    }
     std::random_device rd;
     std::mt19937 gen(rd());
-    std::bernoulli_distribution d(1.0 - p0);
-    return d(gen); // returns 0 or 1
+    std::bernoulli_distribution dist(p1);
+    int result = dist(gen);
+    double norm_factor = std::sqrt(result ? p1 : 1.0 - p1);
+    for (std::size_t i = 0; i < state.size(); ++i) {
+        if (((i & bit) != 0) != static_cast<bool>(result))
+            state[i] = 0;
+        else
+            state[i] /= norm_factor;
+    }
+    return result;
 }
+
+// TODO: implement full state collapse for multi-qubit measurements
+
 } // namespace qpp
+

--- a/runtime/wavefunction.h
+++ b/runtime/wavefunction.h
@@ -2,17 +2,30 @@
 #define QPP_WAVEFUNCTION_H
 
 #include <complex>
-#include <array>
+#include <vector>
+#include <cstddef>
 
 namespace qpp {
 class Wavefunction {
 public:
-    Wavefunction();
-    void apply_h();
-    void apply_x();
-    int measure() const;
-    std::array<std::complex<double>, 2> state;
+    explicit Wavefunction(std::size_t qubits = 1);
+
+    void apply_h(std::size_t qubit);
+    void apply_x(std::size_t qubit);
+    void apply_y(std::size_t qubit);
+    void apply_z(std::size_t qubit);
+    void apply_cnot(std::size_t control, std::size_t target);
+    void apply_s(std::size_t qubit);
+    void apply_t(std::size_t qubit);
+    void apply_swap(std::size_t q1, std::size_t q2);
+
+    int measure(std::size_t qubit);
+
+    std::vector<std::complex<double>> state;
+    std::size_t num_qubits;
 };
-}
+
+// TODO: add more multi-qubit gates and state vector utilities
+} // namespace qpp
 
 #endif // QPP_WAVEFUNCTION_H

--- a/tests/memory_test.cpp
+++ b/tests/memory_test.cpp
@@ -1,0 +1,22 @@
+#include "../runtime/memory.h"
+#include <cassert>
+#include <thread>
+#include <vector>
+#include <iostream>
+
+using namespace qpp;
+
+int main() {
+    constexpr int loops = 10;
+    std::vector<std::thread> threads;
+    for (int i = 0; i < loops; ++i) {
+        threads.emplace_back([](){
+            int id = memory.create_qregister(1);
+            memory.qreg(id).h(0);
+            memory.release_qregister(id);
+        });
+    }
+    for (auto& t : threads) t.join();
+    std::cout << "Memory manager thread test passed." << std::endl;
+    return 0;
+}

--- a/tests/scheduler_test.cpp
+++ b/tests/scheduler_test.cpp
@@ -1,0 +1,28 @@
+#include "../runtime/memory.h"
+#include "../runtime/scheduler.h"
+#include <iostream>
+#include <cassert>
+
+using namespace qpp;
+
+int main() {
+    int qid = memory.create_qregister(1);
+    int result = -1;
+
+    Task t1{"hadamard", Target::QPU, [qid]() {
+        memory.qreg(qid).h(0);
+    }};
+    Task t2{"measure", Target::QPU, [qid, &result]() {
+        result = memory.qreg(qid).measure(0);
+    }};
+
+    scheduler.add_task(t1);
+    scheduler.add_task(t2);
+    scheduler.run();
+
+    assert(result == 0 || result == 1);
+    memory.release_qregister(qid);
+
+    std::cout << "Scheduler test passed." << std::endl;
+    return 0;
+}

--- a/tests/wavefunction_extra_test.cpp
+++ b/tests/wavefunction_extra_test.cpp
@@ -1,0 +1,19 @@
+#include "../runtime/wavefunction.h"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    using namespace qpp;
+    Wavefunction wf(2);
+    wf.apply_x(0);
+    wf.apply_y(1);
+    wf.apply_s(0);
+    wf.apply_t(1);
+    wf.apply_swap(0,1);
+    int m0 = wf.measure(0);
+    int m1 = wf.measure(1);
+    assert(m0 == 0 || m0 == 1);
+    assert(m1 == 0 || m1 == 1);
+    std::cout << "Extra gate tests passed." << std::endl;
+    return 0;
+}

--- a/tests/wavefunction_test.cpp
+++ b/tests/wavefunction_test.cpp
@@ -4,18 +4,28 @@
 #include <iostream>
 
 int main() {
-    qpp::Wavefunction wf;
-    // apply Hadamard gate to |0>
-    wf.apply_h();
-    double p0 = std::norm(wf.state[0]);
-    double p1 = std::norm(wf.state[1]);
-    assert(std::abs(p0 - 0.5) < 1e-6);
-    assert(std::abs(p1 - 0.5) < 1e-6);
-
-    // apply X gate; should swap amplitudes
-    wf.apply_x();
+    using namespace qpp;
+    // single qubit tests
+    Wavefunction wf(1);
+    wf.apply_h(0);
     assert(std::abs(std::norm(wf.state[0]) - 0.5) < 1e-6);
     assert(std::abs(std::norm(wf.state[1]) - 0.5) < 1e-6);
+
+    wf.apply_x(0);
+    wf.apply_y(0);
+    wf.apply_z(0);
+
+    int m = wf.measure(0);
+    assert(m == 0 || m == 1);
+
+    // two qubit entanglement
+    Wavefunction ent(2);
+    ent.apply_h(0);
+    ent.apply_cnot(0,1);
+    double p00 = std::norm(ent.state[0]);
+    double p11 = std::norm(ent.state[3]);
+    assert(std::abs(p00 - 0.5) < 1e-6);
+    assert(std::abs(p11 - 0.5) < 1e-6);
 
     std::cout << "Wavefunction simulator tests passed." << std::endl;
     return 0;

--- a/tools/qpp-run.cpp
+++ b/tools/qpp-run.cpp
@@ -1,10 +1,103 @@
+#include "../runtime/scheduler.h"
+#include "../runtime/memory.h"
+#include <fstream>
 #include <iostream>
+#include <sstream>
+#include <unordered_map>
+
+// Simple interpreter for the toy IR emitted by qppc.
+
+using namespace qpp;
 
 int main(int argc, char** argv) {
     if (argc < 2) {
         std::cerr << "Usage: qpp-run <compiled.ir>\n";
         return 1;
     }
-    std::cout << "Executing " << argv[1] << " (runtime stub)" << std::endl;
+    std::ifstream input(argv[1]);
+    if (!input.is_open()) {
+        std::cerr << "Failed to open " << argv[1] << "\n";
+        return 1;
+    }
+    std::string line;
+    std::string current_name;
+    Target current_target = Target::AUTO;
+    std::vector<std::vector<std::string>> ops;
+
+    auto add_current_task = [&]() {
+        if (current_name.empty()) return;
+        auto instrs = ops;
+        auto name = current_name;
+        auto target = current_target;
+        scheduler.add_task({name, target, [instrs]() {
+            std::unordered_map<std::string,int> qmap;
+            std::unordered_map<std::string,int> cmap;
+            for (const auto& ins : instrs) {
+                if (ins.empty()) continue;
+                if (ins[0] == "QALLOC" && ins.size() == 3) {
+                    int id = memory.create_qregister(std::stoi(ins[2]));
+                    qmap[ins[1]] = id;
+                } else if (ins[0] == "CALLOC" && ins.size() == 3) {
+                    int id = memory.create_cregister(std::stoi(ins[2]));
+                    cmap[ins[1]] = id;
+                } else if (ins[0] == "H" || ins[0] == "X" || ins[0] == "Y" || ins[0] == "Z" || ins[0] == "S" || ins[0] == "T") {
+                    int id = qmap.at(ins[1]);
+                    std::size_t q = std::stoul(ins[2]);
+                    if (ins[0] == "H") memory.qreg(id).h(q);
+                    else if (ins[0] == "X") memory.qreg(id).x(q);
+                    else if (ins[0] == "Y") memory.qreg(id).y(q);
+                    else if (ins[0] == "Z") memory.qreg(id).z(q);
+                    else if (ins[0] == "S") memory.qreg(id).s(q);
+                    else if (ins[0] == "T") memory.qreg(id).t(q);
+                } else if (ins[0] == "SWAP" && ins.size() == 5) {
+                    int id1 = qmap.at(ins[1]);
+                    int id2 = qmap.at(ins[3]);
+                    memory.qreg(id1).swap(std::stoul(ins[2]), std::stoul(ins[4]));
+                } else if (ins[0] == "CNOT" && ins.size() == 5) {
+                    int c = qmap.at(ins[1]);
+                    int t = qmap.at(ins[3]);
+                    memory.qreg(c).cnot(std::stoul(ins[2]), std::stoul(ins[4]));
+                } else if (ins[0] == "MEASURE") {
+                    int qid = qmap.at(ins[1]);
+                    std::size_t qidx = std::stoul(ins[2]);
+                    int result = memory.qreg(qid).measure(qidx);
+                    if (ins.size() == 6 && ins[3] == "->") {
+                        int cid = cmap.at(ins[4]);
+                        std::size_t cidx = std::stoul(ins[5]);
+                        if (cidx < memory.creg(cid).bits.size())
+                            memory.creg(cid).bits[cidx] = result;
+                    }
+                }
+            }
+            for (auto& [name, id] : qmap) memory.release_qregister(id);
+            for (auto& [name, id] : cmap) memory.release_cregister(id);
+        }});
+        ops.clear();
+        current_name.clear();
+    };
+
+    while (std::getline(input, line)) {
+        std::istringstream iss(line);
+        std::string tok;
+        iss >> tok;
+        if (tok == "TASK") {
+            add_current_task();
+            iss >> current_name >> tok; // tok is target
+            if (tok == "CPU") current_target = Target::CPU;
+            else if (tok == "QPU") current_target = Target::QPU;
+            else current_target = Target::AUTO;
+        } else if (tok == "ENDTASK") {
+            add_current_task();
+        } else if (!tok.empty()) {
+            std::vector<std::string> parts;
+            parts.push_back(tok);
+            std::string s;
+            while (iss >> s) parts.push_back(s);
+            ops.push_back(parts);
+        }
+    }
+    add_current_task();
+    scheduler.run();
+    // TODO: surface execution stats and measurement results
     return 0;
 }

--- a/tools/qppc.cpp
+++ b/tools/qppc.cpp
@@ -1,11 +1,14 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <regex>
 #include <string>
 
+// Very small parser generating a trivial IR used by qpp-run.
+// TODO: replace with a proper frontend when language design stabilises.
+
 int main(int argc, char** argv) {
-    if (argc < 2) {
-        std::cerr << "Usage: qppc <source.qpp>\n";
+    if (argc < 3) {
+        std::cerr << "Usage: qppc <source.qpp> <output.ir>\n";
         return 1;
     }
     std::ifstream input(argv[1]);
@@ -13,14 +16,51 @@ int main(int argc, char** argv) {
         std::cerr << "Failed to open " << argv[1] << "\n";
         return 1;
     }
+    std::ofstream out(argv[2]);
+    if (!out.is_open()) {
+        std::cerr << "Failed to create " << argv[2] << "\n";
+        return 1;
+    }
+    std::regex task_regex(R"(task<\s*(CPU|QPU|AUTO)\s*>\s*(\w+)\s*\()") ;
+    std::regex qalloc_regex(R"(qalloc\s+\w+\s+(\w+)\[(\d+)\];)");
+    std::regex creg_regex(R"(cregister\s+\w+\s+(\w+)\[(\d+)\];)");
+    std::regex gate_regex(R"((H|X|Y|Z|S|T)\((\w+)\[(\d+)\]\);)");
+    std::regex swap_regex(R"(SWAP\((\w+)\[(\d+)\],\s*(\w+)\[(\d+)\]\);)");
+    std::regex cnot_regex(R"(CX\((\w+)\[(\d+)\],\s*(\w+)\[(\d+)\]\);)");
+    std::regex meas_assign_regex(R"((\w+)\[(\d+)\]\s*=\s*measure\((\w+)\[(\d+)\]\);)");
+    std::regex measure_regex(R"(measure\((\w+)\[(\d+)\]\);)");
+
     std::string line;
-    std::regex task_regex(R"(task<\s*(CPU|QPU|AUTO)\s*>\s*(\w+)\s*\()");
+    bool in_task = false;
     while (std::getline(input, line)) {
-        std::smatch match;
-        if (std::regex_search(line, match, task_regex)) {
-            std::cout << "Found task '" << match[2] << "' targeting " << match[1] << "\n";
+        std::smatch m;
+        if (std::regex_search(line, m, task_regex)) {
+            out << "TASK " << m[2] << " " << m[1] << "\n";
+            in_task = true;
+            continue;
+        }
+        if (in_task && line.find('}') != std::string::npos) {
+            out << "ENDTASK\n";
+            in_task = false;
+            continue;
+        }
+        if (!in_task) continue;
+        if (std::regex_search(line, m, qalloc_regex)) {
+            out << "QALLOC " << m[1] << " " << m[2] << "\n";
+        } else if (std::regex_search(line, m, creg_regex)) {
+            out << "CALLOC " << m[1] << " " << m[2] << "\n";
+        } else if (std::regex_search(line, m, gate_regex)) {
+            out << m[1] << " " << m[2] << " " << m[3] << "\n";
+        } else if (std::regex_search(line, m, swap_regex)) {
+            out << "SWAP " << m[1] << " " << m[2] << " " << m[3] << " " << m[4] << "\n";
+        } else if (std::regex_search(line, m, cnot_regex)) {
+            out << "CNOT " << m[1] << " " << m[2] << " " << m[3] << " " << m[4] << "\n";
+        } else if (std::regex_search(line, m, meas_assign_regex)) {
+            out << "MEASURE " << m[3] << " " << m[4] << " -> " << m[1] << " " << m[2] << "\n";
+        } else if (std::regex_search(line, m, measure_regex)) {
+            out << "MEASURE " << m[1] << " " << m[2] << "\n";
         }
     }
-    std::cout << "Parsing complete." << std::endl;
+    std::cout << "Compilation complete." << std::endl;
     return 0;
 }


### PR DESCRIPTION
## Summary
- document contributor guidelines in README and new CONTRIBUTING file
- make MemoryManager and Scheduler thread-safe
- support additional gates in Wavefunction and QRegister
- implement a toy IR parser in `qppc` and interpreter in `qpp-run`
- extend the test suite with memory and gate coverage
- add issue templates for bugs and features

## Testing
- `cmake ..`
- `cmake --build . -j2`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6844204c92d8832f8091437cd9be0ece