### PR TITLE
Fix failure message in qpp-run

### DIFF
--- a/tools/qpp-run.cpp
+++ b/tools/qpp-run.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
     }
     std::ifstream input(argv[argi]);
     if (!input.is_open()) {
-        std::cerr << "Failed to open " << argv[1] << "\n";
+        std::cerr << "Failed to open " << argv[argi] << "\n";
         return 1;
     }
     std::string line;


### PR DESCRIPTION
## Summary
- fix qpp-run failure message to print the correct argument
- rebuild and run the full test suite

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 8`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6845f1b5b078832fb123089187f04f4e