### PR TITLE
Add example compilation test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,4 +65,6 @@ if(BUILD_TESTING)
 
     add_test(NAME demo_integration
         COMMAND ${CMAKE_SOURCE_DIR}/tests/demo_integration.sh)
+    add_test(NAME examples_compile_test
+        COMMAND ${CMAKE_SOURCE_DIR}/tests/examples_compile_test.sh)
 endif()

--- a/tests/examples_compile_test.sh
+++ b/tests/examples_compile_test.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+DIR="$(dirname "$0")"
+SRC_DIR="$(cd "$DIR"/.. && pwd)"
+COMPILER="$SRC_DIR/build/qppc"
+for f in "$SRC_DIR"/docs/examples/*.qpp; do
+    echo "Compiling $f"
+    out=$("$COMPILER" "$f" /tmp/out.ir 2>&1)
+    echo "$out"
+    echo "$out" | grep -q "Unrecognized syntax" && exit 1
+    rm -f /tmp/out.ir
+done


### PR DESCRIPTION
## Summary
- add `examples_compile_test.sh` for compiling all docs examples
- integrate new test in `CMakeLists.txt`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(fails: examples_compile_test)*

------
https://chatgpt.com/codex/tasks/task_e_6845f7988d04832f9f525d3d200abd82