### PR TITLE
Clarify compiler subset and simplify example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ For contribution guidelines see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Quick Start Example
 
+`qppc` currently supports a restricted subset of the language focused on
+applying gates and performing measurements. Control-flow constructs and
+other features are not yet implemented.
+
 Compile and run the sample program in `docs/examples/demo.qpp` with:
 
 ```bash
@@ -113,7 +117,9 @@ qpp-run demo.ir
 
 This demonstrates the toy toolchain using the runtime scheduler and wavefunction simulator.
 
-For a more thorough test of the simulator, try `docs/examples/wavefunction_demo.qpp`:
+For a more thorough test of the simulator, try `docs/examples/wavefunction_demo.qpp`.
+This example has been simplified to use only gates and measurements so it
+builds cleanly with the current compiler:
 
 ```bash
 qppc docs/examples/wavefunction_demo.qpp wf.ir

--- a/docs/examples/wavefunction_demo.qpp
+++ b/docs/examples/wavefunction_demo.qpp
@@ -3,13 +3,14 @@
 //   qppc docs/examples/wavefunction_demo.qpp wf.ir
 // Run with:
 //   qpp-run wf.ir
-// This program applies a series of single- and multi-qubit gates,
-// then performs conditional logic based on measurement results.
+// This program applies a series of single- and multi-qubit gates
+// followed by simple measurements. Control flow has been removed
+// because the current `qppc` compiler only supports gates and
+// measurements.
 
 task<QPU> wave_demo() {
     qalloc qbit q[3];
-    cregister int c[1];
-    int m;
+    cregister int c[3];
 
     // prepare entangled state
     H(q[0]);
@@ -28,15 +29,9 @@ task<QPU> wave_demo() {
     CCX(q[0], q[1], q[2]);
     SWAP(q[0], q[2]);
 
-    m = measure(q[0]);
-    if (m) {
-        X(q[1]);
-    } else {
-        Y(q[1]);
-    }
-
-    c[0] = measure(q[1]);
-    c[0] = measure(q[2]);
+    c[0] = measure(q[0]);
+    c[1] = measure(q[1]);
+    c[2] = measure(q[2]);
 }
 
 task<AUTO> main() {


### PR DESCRIPTION
## Summary
- mention `qppc` only supports gate + measurement subset
- simplify `wavefunction_demo.qpp` since compiler lacks control flow
- keep instructions for compiling and running the demo

## Testing
- `cmake ..`
- `make -j $(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6845f797e578832fb19c5067a2b66160