### PR TITLE
Add execution monitoring and checkpoint resume support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,10 @@ if(BUILD_TESTING)
     target_link_libraries(memory_reuse_test PRIVATE qpp_runtime)
     add_test(NAME memory_reuse_test COMMAND memory_reuse_test)
 
+    add_executable(checkpoint_test tests/checkpoint_test.cpp)
+    target_link_libraries(checkpoint_test PRIVATE qpp_runtime)
+    add_test(NAME checkpoint_test COMMAND checkpoint_test)
+
     add_executable(scheduler_pause_test tests/scheduler_pause_test.cpp)
     target_link_libraries(scheduler_pause_test PRIVATE qpp_runtime)
     add_test(NAME scheduler_pause_test COMMAND scheduler_pause_test)

--- a/runtime/memory.cpp
+++ b/runtime/memory.cpp
@@ -1,6 +1,7 @@
 #include "memory.h"
 #include <stdexcept>
 #include <mutex>
+#include <fstream>
 
 namespace qpp {
 int MemoryManager::create_qregister(size_t n) {
@@ -105,6 +106,57 @@ bool MemoryManager::import_state(int id, const std::vector<std::complex<double>>
         return false;
     if (st.size() != qregs[id]->wf.state.size()) return false;
     qregs[id]->wf.state = st;
+    return true;
+}
+
+bool MemoryManager::save_state_to_file(int id, const std::string& path) {
+    std::vector<std::complex<double>> st;
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        if (id < 0 || id >= static_cast<int>(qregs.size()) || !qregs[id])
+            return false;
+        st = qregs[id]->wf.state;
+    }
+    std::ofstream ofs(path, std::ios::binary);
+    if (!ofs) return false;
+    size_t n = st.size();
+    ofs.write(reinterpret_cast<const char*>(&n), sizeof(size_t));
+    ofs.write(reinterpret_cast<const char*>(st.data()), n * sizeof(std::complex<double>));
+    return true;
+}
+
+bool MemoryManager::load_state_from_file(int id, const std::string& path) {
+    std::ifstream ifs(path, std::ios::binary);
+    if (!ifs) return false;
+    size_t n;
+    ifs.read(reinterpret_cast<char*>(&n), sizeof(size_t));
+    std::vector<std::complex<double>> st(n);
+    ifs.read(reinterpret_cast<char*>(st.data()), n * sizeof(std::complex<double>));
+    return import_state(id, st);
+}
+
+bool MemoryManager::checkpoint_if_needed(int id, std::size_t op_threshold,
+                                         double time_threshold_sec,
+                                         const std::string& file) {
+    std::unique_lock<std::mutex> lock(mtx);
+    if (id < 0 || id >= static_cast<int>(qregs.size()) || !qregs[id])
+        return false;
+    QRegister& qr = *qregs[id];
+    bool should = false;
+    if (op_threshold > 0 && qr.op_count >= op_threshold)
+        should = true;
+    if (time_threshold_sec > 0 &&
+        qr.elapsed_seconds() >= time_threshold_sec)
+        should = true;
+    if (!should) return false;
+    std::vector<std::complex<double>> st = qr.wf.state;
+    qr.reset_metrics();
+    lock.unlock();
+    std::ofstream ofs(file, std::ios::binary);
+    if (!ofs) return false;
+    size_t n = st.size();
+    ofs.write(reinterpret_cast<const char*>(&n), sizeof(size_t));
+    ofs.write(reinterpret_cast<const char*>(st.data()), n * sizeof(std::complex<double>));
     return true;
 }
 

--- a/runtime/memory.h
+++ b/runtime/memory.h
@@ -3,28 +3,43 @@
 #include <mutex>
 #include <vector>
 #include <complex>
+#include <chrono>
+#include <string>
 #include "wavefunction.h"
 
 namespace qpp {
 struct QRegister {
     Wavefunction wf;
-    explicit QRegister(size_t n) : wf(n) {}
+    std::size_t op_count{0};
+    std::chrono::steady_clock::time_point start_time;
 
-    void h(std::size_t q) { wf.apply_h(q); }
-    void x(std::size_t q) { wf.apply_x(q); }
-    void y(std::size_t q) { wf.apply_y(q); }
-    void z(std::size_t q) { wf.apply_z(q); }
-    void cnot(std::size_t c, std::size_t t) { wf.apply_cnot(c, t); }
-    void cz(std::size_t c, std::size_t t) { wf.apply_cz(c, t); }
-    void ccnot(std::size_t c1, std::size_t c2, std::size_t t) { wf.apply_ccnot(c1, c2, t); }
-    void s(std::size_t q) { wf.apply_s(q); }
-    void t(std::size_t q) { wf.apply_t(q); }
-    void swap(std::size_t a, std::size_t b) { wf.apply_swap(a, b); }
-    int measure(std::size_t q) { return wf.measure(q); }
-    std::size_t measure(const std::vector<std::size_t>& qs) { return wf.measure(qs); }
-    void reset() { wf.reset(); }
+    explicit QRegister(size_t n)
+        : wf(n), start_time(std::chrono::steady_clock::now()) {}
+
+    void h(std::size_t q) { ++op_count; wf.apply_h(q); }
+    void x(std::size_t q) { ++op_count; wf.apply_x(q); }
+    void y(std::size_t q) { ++op_count; wf.apply_y(q); }
+    void z(std::size_t q) { ++op_count; wf.apply_z(q); }
+    void cnot(std::size_t c, std::size_t t) { ++op_count; wf.apply_cnot(c, t); }
+    void cz(std::size_t c, std::size_t t) { ++op_count; wf.apply_cz(c, t); }
+    void ccnot(std::size_t c1, std::size_t c2, std::size_t t) { ++op_count; wf.apply_ccnot(c1, c2, t); }
+    void s(std::size_t q) { ++op_count; wf.apply_s(q); }
+    void t(std::size_t q) { ++op_count; wf.apply_t(q); }
+    void swap(std::size_t a, std::size_t b) { ++op_count; wf.apply_swap(a, b); }
+    int measure(std::size_t q) { ++op_count; return wf.measure(q); }
+    std::size_t measure(const std::vector<std::size_t>& qs) { op_count += qs.size(); return wf.measure(qs); }
+    void reset() { wf.reset(); reset_metrics(); }
     std::complex<double> amp(std::size_t idx) const { return wf.amplitude(idx); }
-    void resize(std::size_t n) { wf = Wavefunction(n); }
+    void resize(std::size_t n) { wf = Wavefunction(n); reset_metrics(); }
+
+    std::size_t ops() const { return op_count; }
+    double elapsed_seconds() const {
+        return std::chrono::duration<double>(std::chrono::steady_clock::now() - start_time).count();
+    }
+    void reset_metrics() {
+        op_count = 0;
+        start_time = std::chrono::steady_clock::now();
+    }
 };
 
 // TODO(good-first-issue): enhance QRegister with save/load helpers and
@@ -50,6 +65,11 @@ public:
     // state import/export
     std::vector<std::complex<double>> export_state(int id);
     bool import_state(int id, const std::vector<std::complex<double>>& st);
+    bool save_state_to_file(int id, const std::string& path);
+    bool load_state_from_file(int id, const std::string& path);
+    bool checkpoint_if_needed(int id, std::size_t op_threshold,
+                              double time_threshold_sec,
+                              const std::string& file);
 private:
     std::vector<std::unique_ptr<QRegister>> qregs;
     std::vector<std::unique_ptr<CRegister>> cregs;

--- a/tests/checkpoint_test.cpp
+++ b/tests/checkpoint_test.cpp
@@ -1,0 +1,24 @@
+#include "../runtime/memory.h"
+#include <cassert>
+#include <cstdio>
+#include <iostream>
+
+using namespace qpp;
+
+int main() {
+    int id = memory.create_qregister(1);
+    memory.qreg(id).h(0);
+    memory.qreg(id).x(0);
+    bool cp = memory.checkpoint_if_needed(id, 2, 0.0, "cp.bin");
+    assert(cp);
+    assert(memory.qreg(id).ops() == 0);
+    memory.qreg(id).z(0); // mutate after checkpoint
+    bool loaded = memory.load_state_from_file(id, "cp.bin");
+    assert(loaded);
+    std::remove("cp.bin");
+    int m = memory.qreg(id).measure(0);
+    assert(m == 0 || m == 1);
+    memory.release_qregister(id);
+    std::cout << "Checkpoint resume test passed." << std::endl;
+    return 0;
+}

--- a/tools/qpp-run.cpp
+++ b/tools/qpp-run.cpp
@@ -104,6 +104,11 @@ int main(int argc, char** argv) {
                     int targ = qmap.at(ins[5]); // ensure register exists
                     (void)targ;
                     memory.qreg(c1).ccnot(std::stoul(ins[2]), std::stoul(ins[4]), std::stoul(ins[6]));
+                } else if (ins[0] == "CALL" && ins.size() == 2) {
+                    // call support not implemented - ignore
+                    (void)ins[1];
+                } else if (ins[0] == "PRINT" && ins.size() == 2) {
+                    std::cout << ins[1] << std::endl;
                 } else if (ins[0] == "MEASURE") {
                     int qid = qmap.at(ins[1]);
                     std::size_t qidx = std::stoul(ins[2]);

--- a/tools/qppc.cpp
+++ b/tools/qppc.cpp
@@ -32,6 +32,8 @@ int main(int argc, char** argv) {
     std::regex ccx_regex(R"(CCX\((\w+)\[(\d+)\],\s*(\w+)\[(\d+)\],\s*(\w+)\[(\d+)\]\);)");
     std::regex swap_regex(R"(SWAP\((\w+)\[(\d+)\],\s*(\w+)\[(\d+)\]\);)");
     std::regex cnot_regex(R"(CX\((\w+)\[(\d+)\],\s*(\w+)\[(\d+)\]\);)");
+    std::regex call_regex(R"((\w+)\s*\(\s*\);)");
+    std::regex print_regex(R"(printf\(\"([^\"]*)\"\);)");
     std::regex meas_assign_regex(R"((\w+)\[(\d+)\]\s*=\s*measure\((\w+)\[(\d+)\]\);)");
     std::regex meas_var_regex(R"(int\s+(\w+)\s*=\s*measure\((\w+)\[(\d+)\]\);)");
     std::regex measure_regex(R"(measure\((\w+)\[(\d+)\]\);)");
@@ -172,6 +174,10 @@ int main(int argc, char** argv) {
             out << "CCX " << m[1] << " " << m[2] << " " << m[3] << " " << m[4] << " " << m[5] << " " << m[6] << "\n";
         } else if (std::regex_search(line, m, xor_assign_regex)) {
             out << "CNOT " << m[3] << " " << m[4] << " " << m[1] << " " << m[2] << "\n";
+        } else if (std::regex_search(line, m, call_regex)) {
+            out << "CALL " << m[1] << "\n";
+        } else if (std::regex_search(line, m, print_regex)) {
+            out << "PRINT " << m[1] << "\n";
         } else if (std::regex_search(line, m, meas_assign_regex)) {
             out << "MEASURE " << m[3] << " " << m[4] << " -> " << m[1] << " " << m[2] << "\n";
         } else if (std::regex_search(line, m, measure_regex)) {


### PR DESCRIPTION
## Summary
- track gate operations and runtime in `QRegister`
- expose checkpoint helpers in `MemoryManager`
- implement CALL and PRINT parsing in `qppc`
- ignore CALL/PRINT at runtime in `qpp-run`
- add checkpoint unit test

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68460bfcc570832f9ea2ec27a94ef0a6