### PR TITLE
Implement ripple-based periodicity analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ if(BUILD_TESTING)
     target_link_libraries(wavefunction_twoqubit_measure_test PRIVATE qpp_runtime)
     add_test(NAME wavefunction_twoqubit_measure_test COMMAND wavefunction_twoqubit_measure_test)
 
+    add_executable(wavefunction_periodicity_test tests/wavefunction_periodicity_test.cpp)
+    target_link_libraries(wavefunction_periodicity_test PRIVATE qpp_runtime)
+    add_test(NAME wavefunction_periodicity_test COMMAND wavefunction_periodicity_test)
+
     add_executable(scheduler_test tests/scheduler_test.cpp)
     target_link_libraries(scheduler_test PRIVATE qpp_runtime)
     add_test(NAME scheduler_test COMMAND scheduler_test)

--- a/docs/architecture/02-runtime.md
+++ b/docs/architecture/02-runtime.md
@@ -38,6 +38,12 @@ Used when real QPU is not available or during testing:
 - Resolves conditionals using amplitude sampling
 - Emits measurement collapse when required
 
+### Ripple-Based Periodicity Analysis
+The simulator includes `detect_periodicity_ripple(wf)` which performs a simple
+Fourier scan of amplitude magnitudes. When a repeating interference pattern is
+detected above a threshold, the function returns the dominant period. Higher
+level passes can leverage this to compress redundant state segments.
+
 ### Collapse API
 ```cpp
 collapse(q[1]);

--- a/runtime/wavefunction.cpp
+++ b/runtime/wavefunction.cpp
@@ -172,6 +172,38 @@ std::complex<double> Wavefunction::amplitude(std::size_t index) const {
     return state[index];
 }
 
+std::size_t detect_periodicity_ripple(const Wavefunction& wf,
+                                      double threshold) {
+    const auto N = wf.state.size();
+    if (N <= 1) return 0;
+
+    std::vector<double> mags(N);
+    for (std::size_t i = 0; i < N; ++i) {
+        mags[i] = std::abs(wf.state[i]);
+    }
+
+    double energy = 0.0;
+    for (double m : mags) energy += m * m;
+
+    std::size_t best_p = 0;
+    double best_corr = 0.0;
+    for (std::size_t p = 1; p < N; ++p) {
+        double corr = 0.0;
+        for (std::size_t i = 0; i < N; ++i) {
+            corr += mags[i] * mags[(i + p) % N];
+        }
+        if (corr > best_corr) {
+            best_corr = corr;
+            best_p = p;
+        }
+    }
+
+    if (best_p == 0 || energy == 0.0) return 0;
+    double normalized = best_corr / energy;
+    if (normalized < threshold) return 0;
+    return best_p;
+}
+
 // TODO: implement full state collapse for multi-qubit measurements
 
 } // namespace qpp

--- a/runtime/wavefunction.h
+++ b/runtime/wavefunction.h
@@ -31,6 +31,11 @@ public:
     std::size_t num_qubits;
 };
 
+// Analyze amplitude magnitudes using a ripple-based Fourier model.
+// Returns the dominant period length if detected, otherwise 0.
+std::size_t detect_periodicity_ripple(const Wavefunction& wf,
+                                      double threshold = 0.1);
+
 // TODO(good-first-issue): extend with parameterized rotations and register
 // import/export helpers
 } // namespace qpp

--- a/tests/wavefunction_periodicity_test.cpp
+++ b/tests/wavefunction_periodicity_test.cpp
@@ -1,0 +1,20 @@
+#include "../runtime/wavefunction.h"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    using namespace qpp;
+    Wavefunction wf(3);
+    wf.state.assign(1ULL << 3, {0.0,0.0});
+    for (std::size_t i = 0; i < wf.state.size(); i += 2)
+        wf.state[i] = 0.5; // normalized amplitude
+    std::size_t period = detect_periodicity_ripple(wf, 0.1);
+    assert(period == 2);
+
+    wf.reset();
+    period = detect_periodicity_ripple(wf, 0.1);
+    assert(period == 0);
+
+    std::cout << "Ripple periodicity analysis test passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `detect_periodicity_ripple` helper to analyse amplitude cycles
- expose new helper in `wavefunction.h`
- document ripple-based periodicity scan in runtime docs
- test periodicity detection
- build the test via CMake

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: examples_compile_test)*

------
https://chatgpt.com/codex/tasks/task_e_68460c02b800832fac2b13695201b6e7