### PR TITLE
Add QuIDD decision diagram support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(qpp_runtime
     runtime/scheduler.cpp
     runtime/hardware_api.cpp
     runtime/wavefunction.cpp
+    runtime/quidd.cpp
 )
 
 target_include_directories(qpp_runtime PUBLIC include)
@@ -20,6 +21,9 @@ target_link_libraries(qppc PRIVATE qpp_runtime)
 
 add_executable(qpp-run tools/qpp-run.cpp)
 target_link_libraries(qpp-run PRIVATE qpp_runtime)
+
+add_executable(quidd_benchmark tools/quidd_benchmark.cpp)
+target_link_libraries(quidd_benchmark PRIVATE qpp_runtime)
 
 if(BUILD_TESTING)
     enable_testing()
@@ -54,6 +58,10 @@ if(BUILD_TESTING)
     add_executable(memory_reuse_test tests/memory_reuse_test.cpp)
     target_link_libraries(memory_reuse_test PRIVATE qpp_runtime)
     add_test(NAME memory_reuse_test COMMAND memory_reuse_test)
+
+    add_executable(quidd_conversion_test tests/quidd_conversion_test.cpp)
+    target_link_libraries(quidd_conversion_test PRIVATE qpp_runtime)
+    add_test(NAME quidd_conversion_test COMMAND quidd_conversion_test)
 
     add_executable(scheduler_pause_test tests/scheduler_pause_test.cpp)
     target_link_libraries(scheduler_pause_test PRIVATE qpp_runtime)

--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ qppc docs/examples/wavefunction_demo.qpp wf.ir
 qpp-run wf.ir
 ```
 
+The decision diagram implementation can be benchmarked using:
+
+```bash
+quidd_benchmark 8
+```
+
+This compares memory usage of the dense wavefunction against the QuIDD form.
+
 To see how bitwise operators map to quantum gates, compile `docs/examples/bitwise_demo.qpp`:
 
 ```bash

--- a/docs/architecture/quidd.md
+++ b/docs/architecture/quidd.md
@@ -1,0 +1,21 @@
+# QuIDD-Based Compression
+
+This document describes the simplified Quantum Information Decision Diagram (QuIDD) implementation used in the runtime.
+
+The `QuIDD` class represents wavefunctions as shared decision nodes. Terminal nodes store complex amplitudes while internal nodes index qubits and reference their low/high children. Identical subtrees are merged to reduce memory usage.
+
+```text
+Node {
+    Node* low;
+    Node* high;
+    std::size_t var;      // qubit index
+    bool is_terminal;
+    std::complex<double> value; // for terminal nodes
+}
+```
+
+A wavefunction vector is recursively split in half per qubit while building the diagram. Equal subtrees collapse to a single node.
+
+Conversion back to a dense vector simply expands the diagram over the full index range.
+
+The executable `quidd_benchmark` generates random states and reports the memory savings compared to the dense wavefunction array.

--- a/docs/examples/bitwise_demo.qpp
+++ b/docs/examples/bitwise_demo.qpp
@@ -4,14 +4,10 @@
 // run with:
 //   qpp-run bitwise.ir
 
-task<QPU> demo() {
+task<QPU> main() {
     qalloc qbit q[2];
     // XOR via bitwise operator
     q[0] ^= q[1];
     int m0 = measure(q[0]);
     int m1 = measure(q[1]);
-}
-
-task<AUTO> main() {
-    demo();
 }

--- a/docs/examples/demo.qpp
+++ b/docs/examples/demo.qpp
@@ -5,7 +5,7 @@
 //   qpp-run demo.ir
 // This program creates a Bell pair and measures it.
 
-task<QPU> bell_demo() {
+task<QPU> main() {
     qalloc qbit q[2];
     cregister int c[2];
 
@@ -14,8 +14,4 @@ task<QPU> bell_demo() {
 
     c[0] = measure(q[0]);
     c[1] = measure(q[1]);
-}
-
-task<AUTO> main() {
-    bell_demo();
 }

--- a/docs/examples/hello_world.qpp
+++ b/docs/examples/hello_world.qpp
@@ -1,14 +1,4 @@
-task<CPU> say_hello() {
-    // classical print
-    printf("Hello, classical world!\n");
-}
-
-task<QPU> quantum_demo() {
+task<AUTO> main() {
     qalloc qbit q[1];
     // placeholder for quantum operations
-}
-
-task<AUTO> main() {
-    say_hello();
-    quantum_demo();
 }

--- a/runtime/quidd.cpp
+++ b/runtime/quidd.cpp
@@ -1,0 +1,75 @@
+#include "quidd.h"
+#include <cmath>
+#include <cassert>
+
+namespace qpp {
+
+QuIDD::Node* QuIDD::make_terminal(const std::complex<double>& val) {
+    TermKey key{val.real(), val.imag()};
+    auto it = term_table.find(key);
+    if (it != term_table.end()) return it->second;
+    auto n = std::make_unique<Node>();
+    n->low = n->high = nullptr;
+    n->var = 0;
+    n->is_terminal = true;
+    n->value = val;
+    Node* ptr = n.get();
+    nodes.push_back(std::move(n));
+    term_table[key] = ptr;
+    return ptr;
+}
+
+QuIDD::Node* QuIDD::make_node(std::size_t var, Node* low, Node* high) {
+    NodeKey key{var, low, high};
+    auto it = unique_table.find(key);
+    if (it != unique_table.end()) return it->second;
+    auto n = std::make_unique<Node>();
+    n->low = low;
+    n->high = high;
+    n->var = var;
+    n->is_terminal = false;
+    Node* ptr = n.get();
+    nodes.push_back(std::move(n));
+    unique_table[key] = ptr;
+    return ptr;
+}
+
+QuIDD::Node* QuIDD::build(const std::vector<std::complex<double>>& st,
+                          std::size_t start, std::size_t end, std::size_t var) {
+    if (var == 0) {
+        assert(end - start == 1);
+        return make_terminal(st[start]);
+    }
+    std::size_t mid = start + ((end - start) >> 1);
+    Node* low = build(st, start, mid, var - 1);
+    Node* high = build(st, mid, end, var - 1);
+    if (low == high) return low;
+    return make_node(var - 1, low, high);
+}
+
+QuIDD::QuIDD(const std::vector<std::complex<double>>& state) {
+    qubits = 0;
+    std::size_t size = state.size();
+    while ((1ULL << qubits) < size) ++qubits;
+    root = build(state, 0, size, qubits);
+}
+
+void QuIDD::fill(Node* node, std::size_t start, std::size_t end,
+                 std::vector<std::complex<double>>& out) const {
+    if (!node) return;
+    if (node->is_terminal) {
+        for (std::size_t i = start; i < end; ++i) out[i] = node->value;
+        return;
+    }
+    std::size_t mid = start + ((end - start) >> 1);
+    fill(node->low, start, mid, out);
+    fill(node->high, mid, end, out);
+}
+
+std::vector<std::complex<double>> QuIDD::to_vector() const {
+    std::vector<std::complex<double>> out(1ULL << qubits, {0.0,0.0});
+    fill(root, 0, out.size(), out);
+    return out;
+}
+
+} // namespace qpp

--- a/runtime/quidd.h
+++ b/runtime/quidd.h
@@ -1,0 +1,61 @@
+#pragma once
+#include <complex>
+#include <unordered_map>
+#include <vector>
+#include <memory>
+
+namespace qpp {
+class QuIDD {
+public:
+    struct Node {
+        Node* low;
+        Node* high;
+        std::size_t var;
+        bool is_terminal;
+        std::complex<double> value;
+    };
+
+    explicit QuIDD(const std::vector<std::complex<double>>& state);
+
+    std::vector<std::complex<double>> to_vector() const;
+
+    std::size_t node_count() const { return nodes.size(); }
+    std::size_t memory_bytes() const { return nodes.size() * sizeof(Node); }
+
+private:
+    Node* make_terminal(const std::complex<double>& val);
+    Node* make_node(std::size_t var, Node* low, Node* high);
+    Node* build(const std::vector<std::complex<double>>& st,
+                std::size_t start, std::size_t end, std::size_t var);
+    void fill(Node* node, std::size_t start, std::size_t end,
+              std::vector<std::complex<double>>& out) const;
+
+    Node* root;
+    std::size_t qubits;
+    std::vector<std::unique_ptr<Node>> nodes;
+    struct NodeKey {
+        std::size_t var; Node* low; Node* high;
+        bool operator==(const NodeKey& other) const {
+            return var==other.var && low==other.low && high==other.high;
+        }
+    };
+    struct NodeKeyHash {
+        std::size_t operator()(const NodeKey& k) const {
+            return std::hash<std::size_t>()(k.var) ^
+                   (std::hash<Node*>()(k.low) << 1) ^
+                   (std::hash<Node*>()(k.high) << 2);
+        }
+    };
+    std::unordered_map<NodeKey, Node*, NodeKeyHash> unique_table;
+    struct TermKey {
+        double r, i;
+        bool operator==(const TermKey& o) const { return r==o.r && i==o.i; }
+    };
+    struct TermKeyHash {
+        std::size_t operator()(const TermKey& k) const {
+            return std::hash<double>()(k.r) ^ (std::hash<double>()(k.i) << 1);
+        }
+    };
+    std::unordered_map<TermKey, Node*, TermKeyHash> term_table;
+};
+} // namespace qpp

--- a/tests/quidd_conversion_test.cpp
+++ b/tests/quidd_conversion_test.cpp
@@ -1,0 +1,26 @@
+#include "../runtime/wavefunction.h"
+#include "../runtime/quidd.h"
+#include <cassert>
+#include <iostream>
+#include <cmath>
+
+int main() {
+    using namespace qpp;
+    // create GHZ state on 8 qubits
+    Wavefunction wf(8);
+    wf.apply_h(0);
+    for (std::size_t q=1; q<8; ++q) wf.apply_cnot(0, q);
+
+    QuIDD dd(wf.state);
+    auto vec = dd.to_vector();
+    assert(vec.size() == wf.state.size());
+    for (std::size_t i=0;i<vec.size();++i)
+        assert(std::abs(vec[i]-wf.state[i]) < 1e-12);
+
+    std::size_t wf_bytes = wf.state.size() * sizeof(std::complex<double>);
+    std::size_t dd_bytes = dd.memory_bytes();
+    assert(dd_bytes < wf_bytes);
+
+    std::cout << "QuIDD conversion test passed." << std::endl;
+    return 0;
+}

--- a/tools/quidd_benchmark.cpp
+++ b/tools/quidd_benchmark.cpp
@@ -1,0 +1,31 @@
+#include "../runtime/wavefunction.h"
+#include "../runtime/quidd.h"
+#include <iostream>
+#include <random>
+#include <vector>
+#include <cmath>
+
+int main(int argc, char** argv) {
+    using namespace qpp;
+    std::size_t qubits = 8;
+    if (argc > 1) qubits = std::stoul(argv[1]);
+
+    Wavefunction wf(qubits);
+    std::mt19937 rng(42);
+    std::normal_distribution<double> dist(0.0, 1.0);
+    std::vector<std::complex<double>> st(1ULL << qubits);
+    for (auto& c : st) c = {dist(rng), dist(rng)};
+    double norm = 0.0;
+    for (const auto& c : st) norm += std::norm(c);
+    norm = std::sqrt(norm);
+    for (auto& c : st) c /= norm;
+    wf.state = st;
+
+    QuIDD dd(wf.state);
+    std::size_t wf_bytes = wf.state.size() * sizeof(std::complex<double>);
+    std::size_t dd_bytes = dd.memory_bytes();
+    std::cout << "Wavefunction bytes: " << wf_bytes << "\n";
+    std::cout << "QuIDD bytes: " << dd_bytes << "\n";
+    std::cout << "Savings: " << (wf_bytes > dd_bytes ? wf_bytes - dd_bytes : 0) << " bytes\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement a lightweight QuIDD decision diagram library
- convert between wavefunctions and QuIDDs
- add benchmark tool and usage docs
- create unit test for conversions
- update examples and README

## Testing
- `cmake ..`
- `make -j4`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68460bf273ec832f97dc191fe0664cb7