### PR TITLE
Implement multi-qubit measurement collapse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,10 @@ if(BUILD_TESTING)
     target_link_libraries(wavefunction_twoqubit_measure_test PRIVATE qpp_runtime)
     add_test(NAME wavefunction_twoqubit_measure_test COMMAND wavefunction_twoqubit_measure_test)
 
+    add_executable(wavefunction_multi_qubit_collapse_test tests/wavefunction_multi_qubit_collapse_test.cpp)
+    target_link_libraries(wavefunction_multi_qubit_collapse_test PRIVATE qpp_runtime)
+    add_test(NAME wavefunction_multi_qubit_collapse_test COMMAND wavefunction_multi_qubit_collapse_test)
+
     add_executable(fused_gate_test tests/fused_gate_test.cpp)
     target_link_libraries(fused_gate_test PRIVATE qpp_runtime)
     add_test(NAME fused_gate_test COMMAND fused_gate_test)

--- a/runtime/wavefunction.cpp
+++ b/runtime/wavefunction.cpp
@@ -300,18 +300,24 @@ template<typename Real>
 std::size_t Wavefunction<Real>::measure(const std::vector<std::size_t>& qubits) {
     if (qubits.empty()) return 0;
     decompress();
-    // compute probabilities for all outcomes
+
+    // mask covering all measured qubits
+    std::size_t mask = 0;
+    for (auto q : qubits) mask |= 1ULL << q;
+
+    // compute probabilities for each measurement outcome
     std::size_t outcomes = 1ULL << qubits.size();
     std::vector<double> probs(outcomes, 0.0);
+
 #pragma omp parallel
     {
         std::vector<double> local(outcomes, 0.0);
 #pragma omp for schedule(static)
         for (std::size_t i = 0; i < state.size(); ++i) {
+            std::size_t bits = i & mask;
             std::size_t outcome = 0;
-            for (std::size_t q = 0; q < qubits.size(); ++q) {
-                if (i & (1ULL << qubits[q])) outcome |= 1ULL << q;
-            }
+            for (std::size_t j = 0; j < qubits.size(); ++j)
+                if (bits & (1ULL << qubits[j])) outcome |= 1ULL << j;
             local[outcome] += std::norm(state[i]);
         }
 #pragma omp critical
@@ -320,22 +326,25 @@ std::size_t Wavefunction<Real>::measure(const std::vector<std::size_t>& qubits) 
                 probs[o] += local[o];
         }
     }
+
     std::random_device rd;
     std::mt19937 gen(rd());
     std::discrete_distribution<std::size_t> dist(probs.begin(), probs.end());
     std::size_t result = dist(gen);
-    double norm_factor = std::sqrt(probs[result]);
+    double norm_factor = probs[result] > 0 ? std::sqrt(probs[result]) : 1.0;
+
 #pragma omp parallel for schedule(static)
     for (std::size_t i = 0; i < state.size(); ++i) {
+        std::size_t bits = i & mask;
         std::size_t outcome = 0;
-        for (std::size_t q = 0; q < qubits.size(); ++q) {
-            if (i & (1ULL << qubits[q])) outcome |= 1ULL << q;
-        }
-        if (outcome != result)
-            state[i] = 0;
-        else
+        for (std::size_t j = 0; j < qubits.size(); ++j)
+            if (bits & (1ULL << qubits[j])) outcome |= 1ULL << j;
+        if (outcome == result)
             state[i] /= norm_factor;
+        else
+            state[i] = {Real(0.0), Real(0.0)};
     }
+
     return result;
 }
 

--- a/tests/wavefunction_multi_qubit_collapse_test.cpp
+++ b/tests/wavefunction_multi_qubit_collapse_test.cpp
@@ -1,0 +1,37 @@
+#include "../runtime/wavefunction.h"
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+int main() {
+    using namespace qpp;
+    Wavefunction<float> wf(3);
+    wf.apply_h(0);
+    wf.apply_cnot(0,1);
+    wf.apply_cnot(1,2); // GHZ state (|000> + |111>)/sqrt(2)
+
+    std::size_t res = wf.measure(std::vector<std::size_t>{0,2});
+    double norm = 0.0;
+    for (const auto& amp : wf.state) norm += std::norm(amp);
+    assert(std::abs(norm - 1.0) < 1e-6);
+
+    if (res == 0) {
+        // collapsed to |000>
+        for (std::size_t i = 1; i < wf.state.size(); ++i)
+            assert(std::norm(wf.state[i]) < 1e-6);
+        assert(std::abs(wf.state[0] - std::complex<float>(1.0,0.0)) < 1e-6);
+    } else {
+        assert(res == 3);
+        for (std::size_t i = 0; i < wf.state.size(); ++i)
+            if (i != 7) assert(std::norm(wf.state[i]) < 1e-6);
+        assert(std::abs(wf.state[7] - std::complex<float>(1.0,0.0)) < 1e-6);
+    }
+
+    // remaining qubit should match measured value
+    int m1 = wf.measure(1);
+    if (res == 0) assert(m1 == 0); else assert(m1 == 1);
+
+    std::cout << "Multi-qubit collapse test passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- enhance measurement collapse logic for multiple qubits
- add dedicated multi‑qubit collapse test
- register new test with CMake

## Testing
- `cmake ..`
- `make -j`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6846c53d43b8832f9110c3d3f2bc3247