### PR TITLE
Implement lazy wavefunction allocation

### DIFF
--- a/tests/memory_usage_test.cpp
+++ b/tests/memory_usage_test.cpp
@@ -7,6 +7,7 @@ using namespace qpp;
 int main() {
     size_t base = memory.memory_usage();
     int id = memory.create_qregister(2);
+    memory.qreg(id).wave();
     size_t used = memory.memory_usage();
     assert(used > base);
     memory.release_qregister(id);

--- a/tests/wavefunction_sparse_test.cpp
+++ b/tests/wavefunction_sparse_test.cpp
@@ -5,6 +5,7 @@
 int main() {
     using namespace qpp;
     QRegister qr(2);
+    qr.wave();
     // initial state |00>
     qr.compress();
     assert(qr.using_sparse());
@@ -13,10 +14,10 @@ int main() {
     qr.x(1); // state |10>
     qr.compress();
     assert(qr.nnz() == 1);
-    auto amp = qr.wf.amplitude(2);
+    auto amp = qr.wave().amplitude(2);
     assert(std::abs(amp - std::complex<double>(1.0,0.0)) < 1e-9);
     qr.decompress();
-    assert(qr.wf.state[2] == std::complex<double>(1.0,0.0));
+    assert(qr.wave().state[2] == std::complex<double>(1.0,0.0));
     std::cout << "Sparse compression test passed." << std::endl;
     return 0;
 }


### PR DESCRIPTION
## Summary
- allocate QRegister wavefunctions lazily on first use
- provide bulk register creation and release helpers
- update tests for lazy allocation
- remove outdated TODOs

## Testing
- `cmake ..`
- `make -j8`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6846c53c7cbc832f84c368c6c8a94c71