### PR TITLE
Add thread-safe RNG utility

### DIFF
--- a/runtime/random.h
+++ b/runtime/random.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <random>
+#include <atomic>
+#include <thread>
+
+namespace qpp {
+namespace detail {
+inline std::atomic<uint64_t>& rng_seed() {
+    static std::atomic<uint64_t> seed{std::random_device{}()};
+    return seed;
+}
+} // namespace detail
+
+inline std::mt19937& global_rng() {
+    thread_local std::mt19937 gen(detail::rng_seed().load(std::memory_order_relaxed));
+    return gen;
+}
+
+inline void seed_rng(uint64_t seed) {
+    detail::rng_seed().store(seed, std::memory_order_relaxed);
+    global_rng().seed(seed);
+}
+
+} // namespace qpp

--- a/runtime/sparse_wavefunction.cpp
+++ b/runtime/sparse_wavefunction.cpp
@@ -1,6 +1,7 @@
 #include "sparse_wavefunction.h"
 #include <cmath>
 #include <random>
+#include "random.h"
 
 namespace qpp {
 
@@ -74,10 +75,8 @@ int SparseWavefunction::measure(std::size_t qubit) {
     for (const auto& kv : state) {
         if (kv.first & bit) p1 += std::norm(kv.second);
     }
-    std::random_device rd;
-    std::mt19937 gen(rd());
     std::bernoulli_distribution dist(p1);
-    int result = dist(gen);
+    int result = dist(global_rng());
     double norm_factor = std::sqrt(result ? p1 : 1.0 - p1);
     for (auto it = state.begin(); it != state.end(); ) {
         if ( ((it->first & bit) != 0) != static_cast<bool>(result) ) {

--- a/runtime/wavefunction.cpp
+++ b/runtime/wavefunction.cpp
@@ -5,6 +5,7 @@
 #endif
 #include <cmath>
 #include <random>
+#include "random.h"
 #include <unordered_map>
 #include <string>
 #include <array>
@@ -281,10 +282,8 @@ int Wavefunction<Real>::measure(std::size_t qubit) {
         if (i & bit)
             p1 += std::norm(state[i]);
     }
-    std::random_device rd;
-    std::mt19937 gen(rd());
     std::bernoulli_distribution dist(p1);
-    int result = dist(gen);
+    int result = dist(global_rng());
     double norm_factor = std::sqrt(result ? p1 : 1.0 - p1);
 #pragma omp parallel for schedule(static)
     for (std::size_t i = 0; i < state.size(); ++i) {
@@ -320,10 +319,8 @@ std::size_t Wavefunction<Real>::measure(const std::vector<std::size_t>& qubits) 
                 probs[o] += local[o];
         }
     }
-    std::random_device rd;
-    std::mt19937 gen(rd());
     std::discrete_distribution<std::size_t> dist(probs.begin(), probs.end());
-    std::size_t result = dist(gen);
+    std::size_t result = dist(global_rng());
     double norm_factor = std::sqrt(probs[result]);
 #pragma omp parallel for schedule(static)
     for (std::size_t i = 0; i < state.size(); ++i) {

--- a/tests/checkpoint_test.cpp
+++ b/tests/checkpoint_test.cpp
@@ -2,10 +2,12 @@
 #include <cassert>
 #include <cstdio>
 #include <iostream>
+#include "../runtime/random.h"
 
 using namespace qpp;
 
 int main() {
+    seed_rng(42);
     int id = memory.create_qregister(1);
     memory.qreg(id).h(0);
     memory.qreg(id).x(0);

--- a/tests/memory_import_test.cpp
+++ b/tests/memory_import_test.cpp
@@ -1,10 +1,12 @@
 #include "../runtime/memory.h"
 #include <cassert>
 #include <iostream>
+#include "../runtime/random.h"
 
 using namespace qpp;
 
 int main() {
+    seed_rng(42);
     int id = memory.create_qregister(1);
     memory.qreg(id).x(0);
     auto st = memory.export_state(id);

--- a/tests/resonance_zone_cache_test.cpp
+++ b/tests/resonance_zone_cache_test.cpp
@@ -1,10 +1,12 @@
 #include "../runtime/memory.h"
 #include <cassert>
 #include <iostream>
+#include "../runtime/random.h"
 
 using namespace qpp;
 
 int main() {
+    seed_rng(42);
     int id = memory.create_qregister(1);
     memory.qreg(id).x(0);
     bool ok = memory.save_resonance_zone(id, "zone1");

--- a/tests/scheduler_test.cpp
+++ b/tests/scheduler_test.cpp
@@ -2,10 +2,12 @@
 #include "../runtime/scheduler.h"
 #include <iostream>
 #include <cassert>
+#include "../runtime/random.h"
 
 using namespace qpp;
 
 int main() {
+    seed_rng(42);
     int qid = memory.create_qregister(1);
     int result = -1;
 

--- a/tests/sparse_wavefunction_test.cpp
+++ b/tests/sparse_wavefunction_test.cpp
@@ -3,9 +3,11 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>
+#include "../runtime/random.h"
 
 int main() {
     using namespace qpp;
+    seed_rng(42);
     Wavefunction dense(2);
     SparseWavefunction sparse(2);
 

--- a/tests/wavefunction_collapse_test.cpp
+++ b/tests/wavefunction_collapse_test.cpp
@@ -2,9 +2,11 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>
+#include "../runtime/random.h"
 
 int main() {
     using namespace qpp;
+    seed_rng(42);
     Wavefunction<float> wf(2);
     wf.apply_h(0);
     wf.apply_h(1);

--- a/tests/wavefunction_extra_test.cpp
+++ b/tests/wavefunction_extra_test.cpp
@@ -3,9 +3,11 @@
 #include <iostream>
 #include <complex>
 #include <cmath>
+#include "../runtime/random.h"
 
 int main() {
     using namespace qpp;
+    seed_rng(42);
     Wavefunction<float> wf(3);
     wf.apply_x(0);
     wf.apply_y(1);

--- a/tests/wavefunction_test.cpp
+++ b/tests/wavefunction_test.cpp
@@ -2,9 +2,11 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>
+#include "../runtime/random.h"
 
 int main() {
     using namespace qpp;
+    seed_rng(42);
     // single qubit tests
     Wavefunction<float> wf(1);
     wf.apply_h(0);

--- a/tests/wavefunction_twoqubit_measure_test.cpp
+++ b/tests/wavefunction_twoqubit_measure_test.cpp
@@ -3,9 +3,11 @@
 #include <cmath>
 #include <iostream>
 #include <vector>
+#include "../runtime/random.h"
 
 int main() {
     using namespace qpp;
+    seed_rng(42);
     Wavefunction<float> wf(2);
     wf.apply_h(0);
     wf.apply_cnot(0,1);


### PR DESCRIPTION
## Summary
- implement a reusable thread-safe RNG in `runtime/random.h`
- use the RNG in `Wavefunction::measure` and `SparseWavefunction::measure`
- seed the RNG in unit tests to make results reproducible

## Testing
- `cmake ..`
- `cmake --build . -- -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6846c53aa12c832faaa391872746f6ab