### PR TITLE
Add ripple-based periodicity detection

### DIFF
--- a/docs/architecture/02-runtime.md
+++ b/docs/architecture/02-runtime.md
@@ -42,10 +42,12 @@ Used when real QPU is not available or during testing:
   non-zero amplitudes in memory
 
 ### Ripple-Based Periodicity Analysis
-The simulator includes `detect_periodicity_ripple(wf)` which performs a simple
-Fourier scan of amplitude magnitudes. When a repeating interference pattern is
-detected above a threshold, the function returns the dominant period. Higher
-level passes can leverage this to compress redundant state segments.
+The simulator exposes `detect_periodicity_ripple(wf [, thresh])` which performs
+a naive discrete Fourier scan of the amplitude magnitudes. The coefficient with
+the largest magnitude indicates the dominant repeating period in the state. If
+the normalised peak magnitude falls below the provided threshold (default
+`0.05`) the function returns `0`. Higher level passes can leverage the detected
+period to compress redundant state segments or trigger optimisations.
 
 ### Collapse API
 ```cpp

--- a/runtime/wavefunction.cpp
+++ b/runtime/wavefunction.cpp
@@ -453,9 +453,47 @@ bool Wavefunction<Real>::using_sparse() const {
     return is_sparse;
 }
 
+template<typename Real>
+std::size_t detect_periodicity_ripple(const Wavefunction<Real>& wf,
+                                      double threshold) {
+    std::size_t N = wf.using_sparse() ? (1ULL << wf.num_qubits) : wf.state.size();
+    if (N < 2)
+        return 0;
+
+    std::vector<Real> mags(N, Real(0));
+    for (std::size_t i = 0; i < N; ++i) {
+        mags[i] = std::abs(wf.amplitude(i));
+    }
+
+    std::size_t best_k = 0;
+    Real best_amp = Real(0);
+    for (std::size_t k = 1; k <= N / 2; ++k) {
+        std::complex<Real> sum{0.0, 0.0};
+        for (std::size_t n = 0; n < N; ++n) {
+            Real angle = -2.0 * M_PI * Real(k) * Real(n) / Real(N);
+            std::complex<Real> e{std::cos(angle), std::sin(angle)};
+            sum += mags[n] * e;
+        }
+        Real amp = std::abs(sum);
+        if (amp > best_amp) {
+            best_amp = amp;
+            best_k = k;
+        }
+    }
+    if (best_k == 0)
+        return 0;
+    Real norm = best_amp / Real(N);
+    if (norm < threshold)
+        return 0;
+    return N / best_k;
+}
+
 // TODO: implement full state collapse for multi-qubit measurements
 
 template class Wavefunction<double>;
 template class Wavefunction<float>;
+
+template std::size_t detect_periodicity_ripple<double>(const Wavefunction<double>&, double);
+template std::size_t detect_periodicity_ripple<float>(const Wavefunction<float>&, double);
 
 } // namespace qpp

--- a/runtime/wavefunction.h
+++ b/runtime/wavefunction.h
@@ -57,6 +57,14 @@ public:
   std::size_t num_qubits;
 };
 
+// Analyze amplitude magnitudes using a naive discrete Fourier scan and return
+// the dominant repeating period. When no strong periodic component is found the
+// function returns 0. The threshold parameter specifies the minimum normalised
+// Fourier magnitude required for detection.
+template<typename Real = double>
+std::size_t detect_periodicity_ripple(const Wavefunction<Real>& wf,
+                                      double threshold = 0.05);
+
 using WavefunctionF = Wavefunction<float>;
 
 // TODO(good-first-issue): extend with parameterized rotations and register

--- a/tests/wavefunction_periodicity_test.cpp
+++ b/tests/wavefunction_periodicity_test.cpp
@@ -1,6 +1,7 @@
 #include "../runtime/wavefunction.h"
 #include <cassert>
 #include <iostream>
+#include <cmath>
 
 int main() {
     using namespace qpp;


### PR DESCRIPTION
## Summary
- implement `detect_periodicity_ripple` to analyse amplitude ripples
- expose the function in `wavefunction.h`
- test ripple periodicity analysis
- document ripple-based analysis

## Testing
- `cmake ..`
- `make -j2`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6846c539ae34832f90707fe846467812