### PR TITLE
Fix RNG reseeding across threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,10 @@ if(BUILD_TESTING)
     target_link_libraries(qregister_serialization_test PRIVATE qpp_runtime)
     add_test(NAME qregister_serialization_test COMMAND qregister_serialization_test)
 
+    add_executable(random_concurrency_test tests/random_concurrency_test.cpp)
+    target_link_libraries(random_concurrency_test PRIVATE qpp_runtime)
+    add_test(NAME random_concurrency_test COMMAND random_concurrency_test)
+
     add_test(NAME demo_integration
         COMMAND ${CMAKE_SOURCE_DIR}/tests/demo_integration.sh)
     add_test(NAME examples_compile_test

--- a/runtime/random.h
+++ b/runtime/random.h
@@ -12,7 +12,13 @@ inline std::atomic<uint64_t>& rng_seed() {
 } // namespace detail
 
 inline std::mt19937& global_rng() {
-    thread_local std::mt19937 gen(detail::rng_seed().load(std::memory_order_relaxed));
+    thread_local uint64_t last_seed = detail::rng_seed().load(std::memory_order_relaxed);
+    thread_local std::mt19937 gen(last_seed);
+    uint64_t current = detail::rng_seed().load(std::memory_order_relaxed);
+    if (current != last_seed) {
+        gen.seed(current);
+        last_seed = current;
+    }
     return gen;
 }
 

--- a/tests/random_concurrency_test.cpp
+++ b/tests/random_concurrency_test.cpp
@@ -1,0 +1,49 @@
+#include "../runtime/random.h"
+#include <cassert>
+#include <iostream>
+#include <thread>
+#include <vector>
+#include <atomic>
+
+using namespace qpp;
+
+int main() {
+    constexpr int N = 8;
+    std::vector<uint32_t> before(N);
+    std::vector<uint32_t> after(N);
+
+    // seed before launching threads
+    seed_rng(123);
+    {
+        std::vector<std::thread> threads;
+        for (int i = 0; i < N; ++i) {
+            threads.emplace_back([i,&before]() {
+                before[i] = global_rng()();
+            });
+        }
+        for (auto& t : threads) t.join();
+    }
+
+    // launch threads first, then seed
+    std::atomic<bool> go{false};
+    {
+        std::vector<std::thread> threads;
+        for (int i = 0; i < N; ++i) {
+            threads.emplace_back([i,&after,&go]() {
+                while(!go.load()) std::this_thread::yield();
+                after[i] = global_rng()();
+            });
+        }
+        // seed after threads have started
+        seed_rng(123);
+        go.store(true);
+        for (auto& t : threads) t.join();
+    }
+
+    for (int i = 0; i < N; ++i) {
+        assert(before[i] == after[i]);
+    }
+
+    std::cout << "Random concurrency test passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- reseed per-thread RNGs when the global seed changes
- add a new `random_concurrency_test`
- register the test in CMake

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: no member named 'apply_h' in 'std::unique_ptr<qpp::Wavefunction<> >')*
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6846cdba5d48832f8ff7d75b328e8980