### PR TITLE
Update README with RNG usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ pip install -r requirements.txt
 
 For contribution guidelines see [CONTRIBUTING.md](CONTRIBUTING.md).
 
+### Random Number Generation
+
+Utilities in `runtime/random.h` manage pseudo-random sequences used by the
+wavefunction simulator. `global_rng()` returns a thread-local `std::mt19937`
+engine seeded from an atomic value. Use `seed_rng()` to set this seed for
+deterministic behavior. The runtime relies on `global_rng()` when collapsing
+qubits during measurement. The unit tests in `/tests` demonstrate seeding the
+generator with a fixed value before running simulations.
+
 ### Quick Start Example
 
 `qppc` now parses a small but useful subset of Q++ including simple


### PR DESCRIPTION
## Summary
- document `runtime/random.h` RNG utilities

## Testing
- `cmake ..` *(fails: Wavefunction compile errors)*
- `make -j$(nproc)` *(fails: Wavefunction compile errors)*
- `ctest --output-on-failure` *(fails: missing executables)*

------
https://chatgpt.com/codex/tasks/task_e_6846cdb924ac832f8ddf08d19cf0c433