### PR TITLE
Add simple runtime logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ deterministic behavior. The runtime relies on `global_rng()` when collapsing
 qubits during measurement. The unit tests in `/tests` demonstrate seeding the
 generator with a fixed value before running simulations.
 
+### Runtime Logging
+
+The runtime now exposes simple logging helpers in `logger.h`. Messages are
+written to stderr and include a severity level. Use `set_log_level()` to adjust
+verbosity and the `LOG_INFO`, `LOG_WARN`, or `LOG_ERROR` macros to emit output
+from your code.
+
 ### Quick Start Example
 
 `qppc` now parses a small but useful subset of Q++ including simple

--- a/include/logger.h
+++ b/include/logger.h
@@ -1,0 +1,46 @@
+#ifndef QPP_LOGGER_H
+#define QPP_LOGGER_H
+
+#include <iostream>
+#include <mutex>
+#include <string>
+
+namespace qpp {
+
+enum class LogLevel { Error = 0, Warning, Info, Debug };
+
+inline LogLevel current_log_level = LogLevel::Info;
+inline std::mutex log_mtx;
+
+inline void set_log_level(LogLevel level) { current_log_level = level; }
+
+inline const char* level_to_string(LogLevel level) {
+    switch (level) {
+    case LogLevel::Error:
+        return "ERROR";
+    case LogLevel::Warning:
+        return "WARN";
+    case LogLevel::Info:
+        return "INFO";
+    case LogLevel::Debug:
+        return "DEBUG";
+    }
+    return "";
+}
+
+template <typename... Args>
+void log(LogLevel level, Args&&... args) {
+    if (level > current_log_level) return;
+    std::lock_guard<std::mutex> lock(log_mtx);
+    std::cerr << "[" << level_to_string(level) << "] ";
+    (std::cerr << ... << args) << std::endl;
+}
+
+#define LOG_ERROR(...) ::qpp::log(::qpp::LogLevel::Error, __VA_ARGS__)
+#define LOG_WARN(...)  ::qpp::log(::qpp::LogLevel::Warning, __VA_ARGS__)
+#define LOG_INFO(...)  ::qpp::log(::qpp::LogLevel::Info, __VA_ARGS__)
+#define LOG_DEBUG(...) ::qpp::log(::qpp::LogLevel::Debug, __VA_ARGS__)
+
+} // namespace qpp
+
+#endif // QPP_LOGGER_H

--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -1,8 +1,8 @@
 #include "runtime.h"
-#include <iostream>
+#include "logger.h"
 
 namespace qpp {
 void initialize_runtime() {
-    std::cout << "Q++ runtime initialized" << std::endl;
+    LOG_INFO("Q++ runtime initialized");
 }
 }

--- a/runtime/hardware_api.cpp
+++ b/runtime/hardware_api.cpp
@@ -1,5 +1,5 @@
 #include "hardware_api.h"
-#include <iostream>
+#include "logger.h"
 #include <sstream>
 #include <cstdio>
 #include <unistd.h>
@@ -14,12 +14,12 @@ static void invoke_python_backend(const std::string& script,
     char qir_path[] = "/tmp/qpp_qirXXXXXX";
     int fd = mkstemp(qir_path);
     if (fd == -1) {
-        std::cerr << "Failed to create temp file for QIR\n";
+        LOG_ERROR("Failed to create temp file for QIR");
         return;
     }
     FILE* f = fdopen(fd, "w");
     if (!f) {
-        std::cerr << "fdopen failed\n";
+        LOG_ERROR("fdopen failed");
         close(fd);
         return;
     }
@@ -28,7 +28,7 @@ static void invoke_python_backend(const std::string& script,
     std::string cmd = std::string("python3 ") + script + " " + qir_path;
     int rc = std::system(cmd.c_str());
     if (rc != 0)
-        std::cerr << name << " backend execution failed\n";
+        LOG_ERROR(name, " backend execution failed");
     std::remove(qir_path);
 }
 

--- a/runtime/random.h
+++ b/runtime/random.h
@@ -15,7 +15,8 @@ inline std::atomic<uint64_t>& rng_seed() {
 using rng_engine = std::mt19937_64;
 
 inline rng_engine& global_rng() {
-    thread_local rng_engine gen(detail::rng_seed().load(std::memory_order_relaxed));
+    thread_local uint64_t last_seed = detail::rng_seed().load(std::memory_order_relaxed);
+    thread_local rng_engine gen(last_seed);
     uint64_t current = detail::rng_seed().load(std::memory_order_relaxed);
     if (current != last_seed) {
         gen.seed(current);

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -1,7 +1,7 @@
 #include "scheduler.h"
 #include "memory.h"
 #include "hardware_api.h"
-#include <iostream>
+#include "logger.h"
 #include <mutex>
 
 namespace qpp {
@@ -25,31 +25,31 @@ void Scheduler::run() {
             t = tasks.top();
             tasks.pop();
         }
-        std::cout << "Running task '" << t.name << "' on ";
+        std::string msg = "Running task '" + t.name + "' on ";
         switch (t.target) {
         case Target::CPU:
-            std::cout << "CPU";
+            msg += "CPU";
             break;
         case Target::QPU:
-            std::cout << "QPU";
+            msg += "QPU";
             break;
         case Target::AUTO:
-            std::cout << "AUTO";
+            msg += "AUTO";
             break;
         case Target::MIXED:
-            std::cout << "MIXED";
+            msg += "MIXED";
             break;
         }
         if (t.hint == ExecHint::CLIFFORD)
-            std::cout << " [CLIFFORD]";
+            msg += " [CLIFFORD]";
         else if (t.hint == ExecHint::DENSE)
-            std::cout << " [DENSE]";
-        std::cout << std::endl;
+            msg += " [DENSE]";
+        LOG_INFO(msg);
         if (t.handler)
             t.handler();
         if (t.target == Target::QPU && qpu_backend())
             qpu_backend()->execute_qir("; scheduler dispatch\n");
-        std::cout << "Memory in use: " << memory.memory_usage() << " bytes" << std::endl;
+        LOG_DEBUG("Memory in use: ", memory.memory_usage(), " bytes");
     }
     running = false;
 }
@@ -72,31 +72,31 @@ void Scheduler::run_async() {
                 t = tasks.top();
                 tasks.pop();
             }
-            std::cout << "Running task '" << t.name << "' on ";
+            std::string msg = "Running task '" + t.name + "' on ";
             switch (t.target) {
             case Target::CPU:
-                std::cout << "CPU";
+                msg += "CPU";
                 break;
             case Target::QPU:
-                std::cout << "QPU";
+                msg += "QPU";
                 break;
             case Target::AUTO:
-                std::cout << "AUTO";
+                msg += "AUTO";
                 break;
             case Target::MIXED:
-                std::cout << "MIXED";
+                msg += "MIXED";
                 break;
             }
             if (t.hint == ExecHint::CLIFFORD)
-                std::cout << " [CLIFFORD]";
+                msg += " [CLIFFORD]";
             else if (t.hint == ExecHint::DENSE)
-                std::cout << " [DENSE]";
-            std::cout << std::endl;
+                msg += " [DENSE]";
+            LOG_INFO(msg);
             if (t.handler)
                 t.handler();
             if (t.target == Target::QPU && qpu_backend())
                 qpu_backend()->execute_qir("; scheduler dispatch\n");
-            std::cout << "Memory in use: " << memory.memory_usage() << " bytes" << std::endl;
+            LOG_DEBUG("Memory in use: ", memory.memory_usage(), " bytes");
         }
     });
 }


### PR DESCRIPTION
## Summary
- add new `logger.h` with basic logging utilities
- log scheduler and QPU backend activity using new macros
- update random number generator header for missing variable
- mention logging facility in README

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6846d23e0a48832f91ddfba74a65c1df