### PR TITLE
Add memory tracker utility and docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(qpp_runtime
     runtime/sparse_wavefunction.cpp
     runtime/disk_pager.cpp
     runtime/runtime_config.cpp
+    runtime/memory_tracker.cpp
     runtime/quidd.cpp
 )
 
@@ -120,6 +121,10 @@ if(BUILD_TESTING)
     add_executable(memory_usage_test tests/memory_usage_test.cpp)
     target_link_libraries(memory_usage_test PRIVATE qpp_runtime)
     add_test(NAME memory_usage_test COMMAND memory_usage_test)
+
+    add_executable(memory_tracker_test tests/memory_tracker_test.cpp)
+    target_link_libraries(memory_tracker_test PRIVATE qpp_runtime)
+    add_test(NAME memory_tracker_test COMMAND memory_tracker_test)
 
     add_executable(scheduler_pause_test tests/scheduler_pause_test.cpp)
     target_link_libraries(scheduler_pause_test PRIVATE qpp_runtime)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ written to stderr and include a severity level. Use `set_log_level()` to adjust
 verbosity and the `LOG_INFO`, `LOG_WARN`, or `LOG_ERROR` macros to emit output
 from your code.
 
+### Memory Tracker
+
+`memory_tracker` records live memory usage as the scheduler executes tasks.
+Call `memory_tracker.start()` before running tasks and
+`memory_tracker.save_csv("mem.csv")` afterwards to write a CSV log of
+timestamped usage samples.
+
+### Amplitude Heatmap
+
+Use `tools/amplitude_heatmap.py` to visualize amplitude magnitudes and phases
+from a saved state vector. Run the script with a `.npy` file or text list of
+complex numbers to see a 2D or 3D heatmap.
+
 ### Quick Start Example
 
 `qppc` now parses a small but useful subset of Q++ including simple

--- a/runtime/memory_tracker.cpp
+++ b/runtime/memory_tracker.cpp
@@ -1,0 +1,5 @@
+#include "memory_tracker.h"
+
+namespace qpp {
+MemoryTracker memory_tracker;
+} // namespace qpp

--- a/runtime/memory_tracker.h
+++ b/runtime/memory_tracker.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <vector>
+#include <utility>
+#include <chrono>
+#include <string>
+#include <fstream>
+
+namespace qpp {
+struct MemoryTracker {
+    bool enabled = false;
+    std::chrono::steady_clock::time_point start_time;
+    std::vector<std::pair<double, size_t>> samples;
+
+    void start() {
+        enabled = true;
+        start_time = std::chrono::steady_clock::now();
+        samples.clear();
+    }
+
+    void stop() { enabled = false; }
+
+    void record(size_t bytes) {
+        if (!enabled) return;
+        double t = std::chrono::duration<double>(
+                       std::chrono::steady_clock::now() - start_time)
+                       .count();
+        samples.emplace_back(t, bytes);
+    }
+
+    bool save_csv(const std::string& path) const {
+        std::ofstream ofs(path);
+        if (!ofs) return false;
+        for (const auto& p : samples) {
+            ofs << p.first << ',' << p.second << '\n';
+        }
+        return true;
+    }
+};
+
+extern MemoryTracker memory_tracker;
+} // namespace qpp

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -1,5 +1,6 @@
 #include "scheduler.h"
 #include "memory.h"
+#include "memory_tracker.h"
 #include "hardware_api.h"
 #include "logger.h"
 #include <mutex>
@@ -49,7 +50,9 @@ void Scheduler::run() {
             t.handler();
         if (t.target == Target::QPU && qpu_backend())
             qpu_backend()->execute_qir("; scheduler dispatch\n");
-        LOG_DEBUG("Memory in use: ", memory.memory_usage(), " bytes");
+        auto mem = memory.memory_usage();
+        LOG_DEBUG("Memory in use: ", mem, " bytes");
+        memory_tracker.record(mem);
     }
     running = false;
 }
@@ -96,7 +99,9 @@ void Scheduler::run_async() {
                 t.handler();
             if (t.target == Target::QPU && qpu_backend())
                 qpu_backend()->execute_qir("; scheduler dispatch\n");
-            LOG_DEBUG("Memory in use: ", memory.memory_usage(), " bytes");
+            auto mem = memory.memory_usage();
+            LOG_DEBUG("Memory in use: ", mem, " bytes");
+            memory_tracker.record(mem);
         }
     });
 }

--- a/tests/memory_tracker_test.cpp
+++ b/tests/memory_tracker_test.cpp
@@ -1,0 +1,18 @@
+#include "../runtime/memory.h"
+#include "../runtime/memory_tracker.h"
+#include <cassert>
+#include <iostream>
+
+using namespace qpp;
+
+int main() {
+    memory_tracker.start();
+    int id = memory.create_qregister(1);
+    memory.qreg(id).h(0);
+    memory_tracker.record(memory.memory_usage());
+    memory.release_qregister(id);
+    memory_tracker.stop();
+    assert(!memory_tracker.samples.empty());
+    std::cout << "Memory tracker test passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement a `MemoryTracker` utility that records runtime memory usage
- integrate tracker with the scheduler
- provide a new `memory_tracker_test`
- document memory tracker and amplitude heatmap in README

## Testing
- `cmake ..`
- `make -j`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6847535ebe50832f87b7785c3046a75b