### PR TITLE
Feat/more gates

### DIFF
--- a/runtime/sparse_wavefunction.cpp
+++ b/runtime/sparse_wavefunction.cpp
@@ -56,6 +56,24 @@ void SparseWavefunction::apply_h(std::size_t qubit) {
     state.swap(out);
 }
 
+void SparseWavefunction::apply_y(std::size_t qubit) {
+	std::unordered_map<std::size_t, std::complex<double>> out;
+	std::size_t bit = 1ULL << qubit;
+	const auto I = std::complex<double>{0, 1};
+	const auto mI = std::complex<double>{0, -1};
+	for (auto const& kv : state) {
+		auto idx = kv.first;
+		if (idx & bit) {
+			// basis |1> -> |0> with a -i phase
+			out[idx ^ bit] += mI * kv.second;
+		} else {
+			// basis |0> -> |1> with a +1 phase
+			out[idx | bit] += I * kv.second;
+		}
+	}
+	state.swap(out);
+}
+
 void SparseWavefunction::apply_cnot(std::size_t control, std::size_t target) {
     std::unordered_map<std::size_t, std::complex<double>> out;
     std::size_t cbit = 1ULL << control;

--- a/runtime/sparse_wavefunction.cpp
+++ b/runtime/sparse_wavefunction.cpp
@@ -74,6 +74,26 @@ void SparseWavefunction::apply_y(std::size_t qubit) {
 	state.swap(out);
 }
 
+void SparseWavefunction::apply_s(std::size_t qubit) {
+    std::size_t bit = 1ULL << qubit;
+    const auto I = std::complex<double>{0, 1};
+    for (auto& kv : state) {
+        if (kv.first & bit) {
+            kv.second *= I;
+        }
+    }
+}
+
+void SparseWavefunction::apply_t(std::size_t qubit) {
+    std::size_t bit = 1ULL << qubit;
+    const auto phase = std::exp(std::complex<double>{0, M_PI / 4});
+    for (auto& kv : state) {
+        if (kv.first & bit) {
+            kv.second *= phase;
+        }
+    }
+}
+
 void SparseWavefunction::apply_cnot(std::size_t control, std::size_t target) {
     std::unordered_map<std::size_t, std::complex<double>> out;
     std::size_t cbit = 1ULL << control;

--- a/runtime/sparse_wavefunction.h
+++ b/runtime/sparse_wavefunction.h
@@ -13,6 +13,9 @@ public:
     void apply_h(std::size_t qubit);
     void apply_x(std::size_t qubit);
     void apply_z(std::size_t qubit);
+    void apply_y(std::size_t qubit);
+    void apply_s(std::size_t qubit);
+    void apply_t(std::size_t qubit);
     void apply_cnot(std::size_t control, std::size_t target);
     int measure(std::size_t qubit);
     void reset();

--- a/runtime/sparse_wavefunction.h
+++ b/runtime/sparse_wavefunction.h
@@ -17,6 +17,7 @@ public:
     void apply_s(std::size_t qubit);
     void apply_t(std::size_t qubit);
     void apply_cnot(std::size_t control, std::size_t target);
+    
     int measure(std::size_t qubit);
     void reset();
     std::complex<double> amplitude(std::size_t index) const;

--- a/tests/sparse_wavefunction_test.cpp
+++ b/tests/sparse_wavefunction_test.cpp
@@ -8,22 +8,108 @@
 int main() {
     using namespace qpp;
     seed_rng(42);
-    Wavefunction dense(2);
-    SparseWavefunction sparse(2);
 
-    dense.apply_h(0);
-    sparse.apply_h(0);
-    dense.apply_cnot(0,1);
-    sparse.apply_cnot(0,1);
+    // Test H and CNOT gates
+    {
+        Wavefunction dense(2);
+        SparseWavefunction sparse(2);
 
-    for (std::size_t i = 0; i < (1ULL << 2); ++i) {
-        auto d = dense.state[i];
-        auto s = sparse.amplitude(i);
-        assert(std::abs(d - s) < 1e-9);
+        dense.apply_h(0);
+        sparse.apply_h(0);
+        dense.apply_cnot(0,1);
+        sparse.apply_cnot(0,1);
+
+        for (std::size_t i = 0; i < (1ULL << 2); ++i) {
+            auto d = dense.state[i];
+            auto s = sparse.amplitude(i);
+            assert(std::abs(d - s) < 1e-9);
+        }
+
+        int m = sparse.measure(0);
+        assert(m == 0 || m == 1);
+        std::cout << "Sparse wavefunction test passed.\n";
     }
 
-    int m = sparse.measure(0);
-    assert(m == 0 || m == 1);
-    std::cout << "Sparse wavefunction test passed." << std::endl;
+    // Test Y gate
+    {
+        Wavefunction dense(1);
+        SparseWavefunction sparse(1);
+        
+        dense.apply_y(0);
+        sparse.apply_y(0);
+        
+        assert(std::abs(dense.state[0] - sparse.amplitude(0)) < 1e-9);
+        assert(std::abs(dense.state[1] - sparse.amplitude(1)) < 1e-9);
+        assert(std::abs(sparse.amplitude(0)) < 1e-9);
+        assert(std::abs(sparse.amplitude(1) - std::complex<double>(0, 1)) < 1e-9);
+        
+        dense.apply_y(0);
+        sparse.apply_y(0);
+        
+        assert(std::abs(dense.state[0] - sparse.amplitude(0)) < 1e-9);
+        assert(std::abs(dense.state[1] - sparse.amplitude(1)) < 1e-9);
+        assert(std::abs(sparse.amplitude(0) - std::complex<double>(1, 0)) < 1e-9);
+        assert(std::abs(sparse.amplitude(1)) < 1e-9);
+        
+        std::cout << "Y gate test passed.\n";
+    }
+
+    // Test Y, S, and T gates
+    {
+        Wavefunction dense(2);
+        SparseWavefunction sparse(2);
+        
+        dense.apply_y(0);
+        sparse.apply_y(0);
+        dense.apply_s(1);
+        sparse.apply_s(1);
+        dense.apply_t(0);
+        sparse.apply_t(0);
+
+        dense.apply_h(1);
+        sparse.apply_h(1);
+        
+        dense.apply_y(1);
+        sparse.apply_y(1);
+        dense.apply_s(0);
+        sparse.apply_s(0);
+        dense.apply_t(1);
+        sparse.apply_t(1);
+        
+        for (std::size_t i = 0; i < (1ULL << 2); ++i) {
+            auto d = dense.state[i];
+            auto s = sparse.amplitude(i);
+            assert(std::abs(d - s) < 1e-9);
+        }
+        
+        std::cout << "Y, S, T gates test passed.\n";
+    }
+
+    // Combined gates test: H, CNOT, Y, S, T
+    {
+        Wavefunction dense(2);
+        SparseWavefunction sparse(2);
+        
+        dense.apply_h(0);
+        sparse.apply_h(0);
+        dense.apply_cnot(0, 1);
+        sparse.apply_cnot(0, 1);
+        
+        dense.apply_y(0);
+        sparse.apply_y(0);
+        dense.apply_s(1);
+        sparse.apply_s(1);
+        dense.apply_t(0);
+        sparse.apply_t(0);
+        
+        for (std::size_t i = 0; i < (1ULL << 2); ++i) {
+            auto d = dense.state[i];
+            auto s = sparse.amplitude(i);
+            assert(std::abs(d - s) < 1e-9);
+        }
+        
+        std::cout << "Combined gates test passed.\n";
+    }
+
     return 0;
 }


### PR DESCRIPTION
Added sparse implementations for Y (Pauli-Y), S (phase), and T (π/8) gates to match functionality available in dense Wavefunction class.
Added test cases in `sparse_wavefunction_test.cpp` to verify correctness against dense implementation.
Tests include individual gate verification and combined gate ops. All pass.
:)